### PR TITLE
ci:set image registry explicitly on image build script

### DIFF
--- a/config/k8s-dev-setup/global-deployment.yaml
+++ b/config/k8s-dev-setup/global-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: global-server
-          image: global-server:latest
+          image: registry.secapi.cloud/global-server:latest
           # Use 'Always' if you are pushing to a remote registry,
           # or 'IfNotPresent'/'Never' for local images (e.g., with minikube).
           imagePullPolicy: IfNotPresent

--- a/config/k8s-dev-setup/regional-deployment.yaml
+++ b/config/k8s-dev-setup/regional-deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: regional-server:latest
+          image: registry.secapi.cloud/regional-server:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080

--- a/scripts/build-images.sh
+++ b/scripts/build-images.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 # --- Configuration ---
+REGISTRY="registry.secapi.cloud"
 GLOBAL_IMAGE="global-server:latest"
 REGIONAL_IMAGE="regional-server:latest"
 
@@ -11,9 +12,9 @@ REGIONAL_IMAGE="regional-server:latest"
 echo "--- Building Docker images ---"
 
 echo "Building global server image: ${GLOBAL_IMAGE}"
-docker build -t "${GLOBAL_IMAGE}" -f build/Dockerfile.global .
+docker build -t "${REGISTRY}/${GLOBAL_IMAGE}" -f build/Dockerfile.global .
 
 echo "Building regional server image: ${REGIONAL_IMAGE}"
-docker build -t "${REGIONAL_IMAGE}" -f build/Dockerfile.regional .
+docker build -t "${REGISTRY}/${REGIONAL_IMAGE}" -f build/Dockerfile.regional .
 
 echo "--- Docker images built successfully! ---"

--- a/scripts/setup-dev-clusters.sh
+++ b/scripts/setup-dev-clusters.sh
@@ -12,8 +12,8 @@ GLOBAL_KUBECONFIG_PATH="${KUBECONFIG_DIR}/global-config"
 REGIONAL_KUBECONFIG_PATH="${KUBECONFIG_DIR}/regional-config"
 
 # Docker Images
-GLOBAL_IMAGE="global-server:latest"
-REGIONAL_IMAGE="regional-server:latest"
+GLOBAL_IMAGE="registry.secapi.cloud/global-server:latest"
+REGIONAL_IMAGE="registry.secapi.cloud/regional-server:latest"
 
 # Deployment and CRD files
 GLOBAL_DEPLOYMENT_YAML="config/k8s-dev-setup/global-deployment.yaml"


### PR DESCRIPTION
This PR modify the image build script in order to set explicitly a image registry for both global and regional control plane server images.

That is considered a good practice because it avoids to send images to unwanted registries.

Also, it solves a compatibility issue caused by divergent default behaviors of different container engines when images are built without set a registry.

Closes the issue: https://github.com/eu-sovereign-cloud/ecp/issues/39