### PR TITLE
fix: workspace namespacing

### DIFF
--- a/foundation/gateway/cmd/regionalapiserver.go
+++ b/foundation/gateway/cmd/regionalapiserver.go
@@ -151,9 +151,18 @@ func startRegional(logger *slog.Logger, addr string, kubeconfigPath string) {
 	)
 
 	// Workspace writer adapter that also manages namespace lifecycle
-	workspaceWriterAdapter := kubernetes.NewNamespaceManagingWriterAdapter(
+	// workspaceWriterAdapter := kubernetes.NewNamespaceManagingWriterAdapter(
+	// 	client.Client,
+	// 	client.ClientSet,
+	// 	workspacev1.WorkspaceGVR,
+	// 	logger,
+	// 	kubernetes.MapWorkspaceDomainToCR,
+	// 	kubernetes.MapCRToWorkspaceDomain,
+	// )
+
+	// Workspace reader adapter
+	workspaceWriterAdapter := kubernetes.NewWriterAdapter(
 		client.Client,
-		client.ClientSet,
 		workspacev1.WorkspaceGVR,
 		logger,
 		kubernetes.MapWorkspaceDomainToCR,

--- a/foundation/gateway/internal/controller/regional/workspace/delete_workspace.go
+++ b/foundation/gateway/internal/controller/regional/workspace/delete_workspace.go
@@ -18,7 +18,6 @@ func (c *DeleteWorkspace) Do(ctx context.Context, ir port.IdentifiableResource) 
 	domain.Name = ir.GetName()
 	domain.Tenant = ir.GetTenant()
 	domain.ResourceVersion = ir.GetVersion()
-	domain.Workspace = ir.GetWorkspace()
 
 	// soft delete
 	state := regional.ResourceStateDeleting

--- a/foundation/gateway/pkg/adapter/kubernetes/regional_mapper.go
+++ b/foundation/gateway/pkg/adapter/kubernetes/regional_mapper.go
@@ -118,8 +118,10 @@ func MapCRToWorkspaceDomain(obj client.Object) (*regional.WorkspaceDomain, error
 			Provider:        internalLabels[labels.InternalProviderLabel],
 		},
 		Scope: scope.Scope{
-			Tenant:    internalLabels[labels.InternalTenantLabel],
-			Workspace: cr.GetName(),
+			Tenant: internalLabels[labels.InternalTenantLabel],
+			// Workspaces do not have a workspace scope as they are a higher level resource, scoped only by tenant.
+			// Setting it to empty avoids incorrect namespace computation.
+			Workspace: "",
 		},
 		Region:      internalLabels[labels.InternalRegionLabel],
 		Labels:      labels.KeyedToOriginal(keyedLabels, cr.RegionalCommonData.Labels),

--- a/foundation/gateway/pkg/api/workspace/workspace.go
+++ b/foundation/gateway/pkg/api/workspace/workspace.go
@@ -52,8 +52,10 @@ func APIToDomain(api schema.Workspace, params port.IdentifiableResource) *region
 				ResourceVersion: params.GetVersion(),
 			},
 			Scope: scope.Scope{
-				Tenant:    params.GetTenant(),
-				Workspace: params.GetName(),
+				Tenant: params.GetTenant(),
+				// Workspaces do not have a workspace scope as they are a higher level resource, scoped only by tenant.
+				// Setting it to empty avoids incorrect namespace computation.
+				Workspace: "",
 			},
 			Annotations: api.Annotations,
 			Labels:      api.Labels,


### PR DESCRIPTION
Changes in this PR ensure that the namespace is computed only based on tenant for workspace operations.
Currently the assumption is that the workspace controller will handle it's owned namespace creation.
- `MapCRToWorkspaceDomain` no longer sets a `workspace` value in resource scope
- workspace `APIToDomain` no longer sets a `workspace` value in resource scope
- revert to `NewWriterAdapter` for workspace controller