### PR TITLE
fix(tooling): repair e2e/csp plugin paths after foundation→framework refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ hooks-unskip-pre-merge:
 #
 # The go-sdk source is consumed two ways:
 #   1. As a git submodule at modules/go-sdk, used by CRD generation.
-#   2. As a Go module dependency declared in foundation/gateway/go.mod.
+#   2. As a Go module dependency declared in gateway/go.mod.
 # Both must point at the same upstream tag — otherwise the generated CRDs and
 # the compiled types drift apart, and code reviewers can no longer trust that
 # the schemas in the repo match what the binary actually understands.
@@ -95,7 +95,7 @@ go-sdk-update:
 	@#
 	@# We use `go mod edit` + `go mod download` instead of `go get` because
 	@# `go get` builds the full module graph and tries to fetch
-	@# foundation/persistence@v0.0.1 from the proxy — that pseudo-version only
+	@# framework@v0.0.1 from the proxy — that pseudo-version only
 	@# resolves via the workspace-level replace, which `go get` ignores. The
 	@# edit+download combo pins the require and populates go.sum for just the
 	@# bumped package, which is all we need.
@@ -122,9 +122,9 @@ go-sdk-verify:
 # Per-module vulnerability check (govulncheck)
 #
 # Usage:
-#   make foundation/persistence-vuln          # single module
+#   make framework-vuln          # single module
 #   make vuln                                 # all GO_MODULES (parallelisable: -jN)
-#   make foundation/persistence-vuln-ctzd     # via tools container
+#   make framework-vuln-ctzd     # via tools container
 #
 # GOWORK=off forces single-module mode so the scan stays scoped to the
 # module's own go.mod. Without it, Go walks up to the repo-root go.work and
@@ -147,11 +147,11 @@ vuln: $(addsuffix -vuln,$(GO_MODULES))
 # Per-module tests
 #
 # Usage:
-#   make foundation/persistence-test                     # all tests, one module
+#   make framework-test                     # all tests, one module
 #   make test                                            # all modules
 #   make test RUN=TestCreateFoo                          # filter by name
 #   make test RUN='TestFoo|TestBar'                      # regex (quote to protect from shell)
-#   make foundation/persistence-test-ctzd RUN=TestFoo    # via tools container
+#   make framework-test-ctzd RUN=TestFoo    # via tools container
 #
 # RUN is optional. When set it is forwarded verbatim to `go test -run <regex>`,
 # which matches the test's fully qualified name (Go's own filter semantics —
@@ -185,9 +185,9 @@ test-envtest:
 # Per-module lint (golangci-lint)
 #
 # Usage:
-#   make foundation/persistence-lint
+#   make framework-lint
 #   make lint
-#   make foundation/persistence-lint-ctzd
+#   make framework-lint-ctzd
 #
 # Uses the pinned golangci-lint from ci/tools/bin/ (via tools-install).
 # Workspace mode is kept so cross-module replaces resolve correctly.
@@ -205,12 +205,12 @@ lint: $(addsuffix -lint,$(GO_MODULES))
 # Per-module gofmt (golangci-lint fmt)
 #
 # Usage:
-#   make foundation/gateway-gofmt              # auto-fix one module
+#   make gateway-gofmt              # auto-fix one module
 #   make gofmt                                 # auto-fix all modules
-#   make foundation/gateway-gofmt-check        # check one module (fails on diff)
+#   make gateway-gofmt-check        # check one module (fails on diff)
 #   make gofmt-check                           # check all modules (CI gate)
-#   make foundation/gateway-gofmt-ctzd         # via tools container
-#   make foundation/gateway-gofmt-check-ctzd   # via tools container
+#   make gateway-gofmt-ctzd         # via tools container
+#   make gateway-gofmt-check-ctzd   # via tools container
 #
 # Uses `golangci-lint fmt`, which applies the formatters configured in
 # .golangci.yml (gofmt simplify + goimports). This keeps `make gofmt` and
@@ -243,9 +243,9 @@ gofmt-check: $(addsuffix -gofmt-check,$(GO_MODULES))
 # Per-module gosec
 #
 # Usage:
-#   make foundation/persistence-gosec
+#   make framework-gosec
 #   make gosec
-#   make foundation/persistence-gosec-ctzd
+#   make framework-gosec-ctzd
 #
 # Runs with the Go workspace active (go.work) so that cross-module imports
 # resolve correctly. The pinned gosec binary (GOSEC_VERSION in .config.mk)
@@ -289,14 +289,14 @@ generate-api-verify: generate-api
 # Per-module: go mod tidy
 #
 # Usage:
-#   make foundation/gateway-tidy          # single module
+#   make gateway-tidy          # single module
 #   make tidy                             # all GO_MODULES
-#   make foundation/gateway-tidy-ctzd     # inside tools container
+#   make gateway-tidy-ctzd     # inside tools container
 #
 # CAVEAT: `go mod tidy` intentionally ignores go.work, so it runs the module
 # in single-module mode. If a module imports packages from another workspace
 # member and relies on go.work's `replace (...)` block to resolve them (as
-# foundation/delegator does against foundation/gateway and foundation/persistence),
+# csp/aruba does against gateway and framework),
 # tidy will fail trying to fetch the v0.0.1 pseudo-version from the proxy.
 #
 # Use this target only on modules whose imports resolve in isolation, or
@@ -319,8 +319,8 @@ tidy: $(addsuffix -tidy,$(GO_MODULES))
 # Per-module: go get <pkg[@version]>
 #
 # PKG is required; include @version to pin (or @latest to upgrade).
-#   make foundation/gateway-go-get PKG=github.com/foo/bar@v1.2.3
-#   make foundation/gateway-go-get-ctzd PKG=github.com/foo/bar@v1.2.3
+#   make gateway-go-get PKG=github.com/foo/bar@v1.2.3
+#   make gateway-go-get-ctzd PKG=github.com/foo/bar@v1.2.3
 #
 # The umbrella `go-get` target runs the same PKG in every GO_MODULE — useful for
 # bumping a shared dependency across the workspace in one shot:
@@ -329,7 +329,7 @@ tidy: $(addsuffix -tidy,$(GO_MODULES))
 # NOTE: We deliberately use `go mod edit -require=…@VERSION` + `go mod download`
 # instead of `go get` + `go mod tidy`. Using `go get` or `go mod tidy` rebuilds
 # the full module graph and tries to fetch sibling workspace modules (e.g.
-# foundation/persistence@v0.0.1) from the module proxy — pseudo-versions that
+# framework@v0.0.1) from the module proxy — pseudo-versions that
 # only resolve via the workspace `replace` directives, which the proxy never
 # has. The edit+download approach updates go.mod and go.sum for the target
 # package without touching the rest of the module graph.
@@ -449,13 +449,13 @@ pre-merge: gh-token-ensure branch-rebase-verify workspace-verify go-sdk-verify g
 # Workspace membership: add / remove a module from go.work
 #
 # RELPATH is the path relative to the repo root.
-#   make workspace-use-add  RELPATH=foundation/plugin/newthing
-#   make workspace-use-drop RELPATH=foundation/plugin/oldthing
+#   make workspace-use-add  RELPATH=csp/newthing
+#   make workspace-use-drop RELPATH=csp/oldthing
 #
 # These targets only manipulate the `use (...)` block. The `replace (...)` block
-# in go.work pins foundation modules to their local paths at v0.0.1, which is
+# in go.work pins workspace modules to their local paths at v0.0.1, which is
 # load-bearing for %-vuln and %-gosec (both use GOWORK=off). After adding
-# a new foundation module, also run:
+# a new workspace module, also run:
 #
 #   go work edit -replace <modpath>=./$(RELPATH)
 #

--- a/csp/dummy/Makefile
+++ b/csp/dummy/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Dummy Delegator Plugin
 
-include ../../../.config.mk
+include ../../.config.mk
 
 # =====================================================================================
 # Variables

--- a/csp/dummy/scripts/build.sh
+++ b/csp/dummy/scripts/build.sh
@@ -13,7 +13,7 @@ else
 fi
 
 
-DOCKER_BUILD_CONTEXT="${SCRIPT_DIR}/../../../.."
+DOCKER_BUILD_CONTEXT="${SCRIPT_DIR}/../../.."
 DOCKERFILE_PATH="${SCRIPT_DIR}/../build/Dockerfile"
 
 docker build --build-arg DLV_VERSION="${DLV_VERSION}" -t "${IMAGE_NAME}" -f "${DOCKERFILE_PATH}" "${DOCKER_BUILD_CONTEXT}"

--- a/csp/dummy/scripts/deploy.sh
+++ b/csp/dummy/scripts/deploy.sh
@@ -10,7 +10,7 @@ VERSION=${VERSION:-"latest"}
 KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
 export KUBECONFIG
 
-CRDS_DIR="${SCRIPT_DIR}/../../../persistence/generated/crds"
+CRDS_DIR="${SCRIPT_DIR}/../../../resources/testdata/crds"
 DEPLOY_DIR="${SCRIPT_DIR}/../deploy"
 
 # Set image name for kustomize

--- a/csp/dummy/scripts/kind-start.sh
+++ b/csp/dummy/scripts/kind-start.sh
@@ -25,7 +25,7 @@ fi
 
 # The kustomize binary is optional, deploy.sh will use 'kubectl -k' as a fallback.
 
-"${SCRIPT_DIR}/../../../../ci/scripts/kind-cgroup-preflight.sh"
+"${SCRIPT_DIR}/../../../ci/scripts/kind-cgroup-preflight.sh"
 
 echo "Creating KIND cluster '${CLUSTER_NAME}'..."
 kind create cluster --name "${CLUSTER_NAME}"

--- a/csp/ionos/README.md
+++ b/csp/ionos/README.md
@@ -159,5 +159,4 @@ Map Workspace to IonOS Server or Datacenters as needed.
 - Implement the full plugin logic with proper error handling and status synchronization.
 - Add unit tests for plugin methods.
 - Enhance integration tests to verify actual IonOS resource creation (requires real credentials).
-- Handle advanced features like snapshots, backups, etc., if supported by the model.</content>
-<parameter name="filePath">/home/cguran/surse/seca/ecp/foundation/plugin/ionos/README.md
+- Handle advanced features like snapshots, backups, etc., if supported by the model.

--- a/csp/ionos/deploy/Makefile
+++ b/csp/ionos/deploy/Makefile
@@ -57,13 +57,13 @@ docker-build-plugin:
 	docker build \
 		-f ../build/Dockerfile \
 		-t $(PLUGIN_IMAGE) \
-		../../../../
+		../../../
 
 # Install ECP CRDs on the regional cluster (required for the plugin manager to sync caches)
 install-ecp-crds-on-regional:
 	@if [[ -z "$$REGIONAL_KUBECONFIG" ]]; then echo "Error: REGIONAL_KUBECONFIG must be set"; exit 1; fi
-	kubectl --kubeconfig $$REGIONAL_KUBECONFIG apply -f ../../../persistence/generated/crds/workspace/workspace.v1.secapi.cloud_workspaces.yaml
-	kubectl --kubeconfig $$REGIONAL_KUBECONFIG apply -f ../../../persistence/generated/crds/storage/storage.v1.secapi.cloud_block-storages.yaml
+	kubectl --kubeconfig $$REGIONAL_KUBECONFIG apply -f ../../../resources/testdata/crds/workspace/workspace.v1.secapi.cloud_workspaces.yaml
+	kubectl --kubeconfig $$REGIONAL_KUBECONFIG apply -f ../../../resources/testdata/crds/storage/storage.v1.secapi.cloud_block-storages.yaml
 
 # Load the plugin image into the regional cluster and apply the Deployment manifest.
 # Requires REGIONAL_KUBECONFIG to point at the regional cluster kubeconfig.

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -1,6 +1,6 @@
 # Makefile for e2e Plugin
 
-include ../../../.config.mk
+include ../../.config.mk
 
 # =====================================================================================
 # Variables

--- a/test/e2e/build/delegator/Dockerfile
+++ b/test/e2e/build/delegator/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy the manager binary from the builder stage
 WORKDIR /app
-COPY --from=builder /workspace/foundation/plugin/e2e/delegator .
+COPY --from=builder /workspace/test/e2e/delegator .
 
 # Copy dlv (Delve debugger) for debugging. Assume dlv is in /go/bin in the builder image.
 COPY --from=builder /go/bin/dlv /usr/local/bin/dlv

--- a/test/e2e/scripts/build.sh
+++ b/test/e2e/scripts/build.sh
@@ -12,7 +12,7 @@ FULL_IMAGE_NAME=$IMAGE_NAME
 USE_KIND=true setup_registry_vars "$1"
 LOCAL_IMAGE_NAME=$IMAGE_NAME
 
-DOCKER_BUILD_CONTEXT="${SCRIPT_DIR}/../../../.."
+DOCKER_BUILD_CONTEXT="${SCRIPT_DIR}/../../.."
 DOCKERFILE_PATH="${SCRIPT_DIR}/../build/${COMPONENT}/Dockerfile"
 
 # Build with the full name

--- a/test/e2e/scripts/clean-crds.sh
+++ b/test/e2e/scripts/clean-crds.sh
@@ -4,7 +4,7 @@ source "$(dirname "$0")/common.sh"
 setup_env
 setup_kube_vars
 
-CRDS_DIR="${SCRIPT_DIR}/../../../persistence/generated/crds"
+CRDS_DIR="${SCRIPT_DIR}/../../../resources/testdata/crds"
 
 if [ -d "${CRDS_DIR}" ]; then
     echo "Cleaning CRDs from ${CRDS_DIR}..."

--- a/test/e2e/scripts/deploy.sh
+++ b/test/e2e/scripts/deploy.sh
@@ -9,7 +9,7 @@ setup_kube_vars
 setup_registry_vars "$1"
 
 DEPLOY_DIR="${SCRIPT_DIR}/../deploy/${COMPONENT}"
-CRDS_DIR="${SCRIPT_DIR}/../../../persistence/generated/crds"
+CRDS_DIR="${SCRIPT_DIR}/../../../resources/testdata/crds"
 
 echo "Applying CRDs from ${CRDS_DIR}..."
 find "${CRDS_DIR}" -type f -name "*.yaml" -exec cat {} + | kubectl ${KUBECONFIG_ARG} apply -f -
@@ -27,11 +27,15 @@ if [[ -n "$USE_KIND" && "$USE_KIND" == "true" ]]; then
     YAML_STREAM=$(echo "${YAML_STREAM}" | sed "s|imagePullPolicy: Always|imagePullPolicy: IfNotPresent|g")
 fi
 
-# If the component is the delegator, handle the plugin type
+# If the component is the delegator, handle the plugin type.
+# PLUGIN_TYPE may be overridden via the environment; otherwise default to
+# aruba, except on KIND where the dummy plugin is the default.
 if [ "$COMPONENT" == "delegator" ]; then
-    PLUGIN_TYPE="aruba" # Default to aruba
-    if [[ -n "$USE_KIND" && "$USE_KIND" == "true" ]]; then
-        PLUGIN_TYPE="dummy"
+    if [ -z "$PLUGIN_TYPE" ]; then
+        PLUGIN_TYPE="aruba" # Default to aruba
+        if [[ -n "$USE_KIND" && "$USE_KIND" == "true" ]]; then
+            PLUGIN_TYPE="dummy"
+        fi
     fi
     echo "Deploying delegator with plugin: ${PLUGIN_TYPE}"
     YAML_STREAM=$(echo "${YAML_STREAM}" | sed "s|##PLUGIN_TYPE##|${PLUGIN_TYPE}|g")

--- a/test/e2e/scripts/kind-start.sh
+++ b/test/e2e/scripts/kind-start.sh
@@ -18,7 +18,7 @@ then
     exit 1
 fi
 
-"${SCRIPT_DIR}/../../../../ci/scripts/kind-cgroup-preflight.sh"
+"${SCRIPT_DIR}/../../../ci/scripts/kind-cgroup-preflight.sh"
 
 echo "Creating KIND cluster '${CLUSTER_NAME}'..."
 kind create cluster --name "${CLUSTER_NAME}"


### PR DESCRIPTION
## Summary
- Repairs e2e/csp plugin paths that broke during the `foundation` → `framework`/`csp` refactor.
- Fixes stale module-name references in docs left over from the same refactor.
