### PR TITLE
test(e2e): standalone gateway suites + faster delegator suite

### DIFF
--- a/csp/dummy/pkg/plugin/block_storage.go
+++ b/csp/dummy/pkg/plugin/block_storage.go
@@ -29,10 +29,14 @@ func (b *BlockStorage) IncreaseSize(ctx context.Context, resource *bsdom.BlockSt
 	return simulateBS(ctx, "increase-size", resource, 2*blockStorageDelay(), b.logger)
 }
 
+// blockStorageDelay returns the simulated latency of a block storage operation.
+// The values are deliberately small: they only need to outlast a reconcile requeue
+// (1s in the e2e delegator) so the pending→active lifecycle is exercised, while
+// keeping the integration suites fast. IncreaseSize doubles this.
 func blockStorageDelay() time.Duration {
-	const base int = 30
+	const base int = 3
 
-	variation := rand.IntN(60) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
+	variation := rand.IntN(4) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
 
 	return time.Duration(base+variation) * time.Second
 }

--- a/csp/dummy/pkg/plugin/image.go
+++ b/csp/dummy/pkg/plugin/image.go
@@ -25,11 +25,12 @@ func (i *Image) Delete(ctx context.Context, resource *imgdom.Image) error {
 	return simulateImage(ctx, "delete", resource, imageDelay(), i.logger)
 }
 
-// imageDelay returns the simulated latency of an image operation.
+// imageDelay returns the (short) simulated latency of an image operation. See
+// blockStorageDelay for why the values are kept small.
 func imageDelay() time.Duration {
-	const base int = 30
+	const base int = 3
 
-	variation := rand.IntN(60) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
+	variation := rand.IntN(4) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
 
 	return time.Duration(base+variation) * time.Second
 }

--- a/csp/dummy/pkg/plugin/network.go
+++ b/csp/dummy/pkg/plugin/network.go
@@ -25,10 +25,13 @@ func (n *Network) Delete(ctx context.Context, resource *netdom.Network) error {
 	return simulateNet(ctx, "delete", resource, networkDelay(), n.logger)
 }
 
+// networkDelay returns the (short) simulated latency of a network operation; nic,
+// internet gateway and public IP reuse it. See blockStorageDelay for why the values
+// are kept small.
 func networkDelay() time.Duration {
-	const base int = 30
+	const base int = 3
 
-	variation := rand.IntN(60) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
+	variation := rand.IntN(4) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
 
 	return time.Duration(base+variation) * time.Second
 }

--- a/csp/dummy/pkg/plugin/role.go
+++ b/csp/dummy/pkg/plugin/role.go
@@ -29,11 +29,12 @@ func (ro *Role) Delete(ctx context.Context, resource *roledom.Role) error {
 	return simulateRole(ctx, "delete", resource, roleDelay(), ro.logger)
 }
 
-// roleDelay returns the simulated latency of a role operation.
+// roleDelay returns the (short) simulated latency of a role operation. See
+// blockStorageDelay for why the values are kept small.
 func roleDelay() time.Duration {
-	const base int = 5
+	const base int = 1
 
-	variation := rand.IntN(10) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
+	variation := rand.IntN(2) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
 
 	return time.Duration(base+variation) * time.Second
 }

--- a/csp/dummy/pkg/plugin/role_assignment.go
+++ b/csp/dummy/pkg/plugin/role_assignment.go
@@ -25,11 +25,12 @@ func (ra *RoleAssignment) Delete(ctx context.Context, resource *radom.RoleAssign
 	return simulateRA(ctx, "delete", resource, roleAssignmentDelay(), ra.logger)
 }
 
-// roleAssignmentDelay returns the simulated latency of a role assignment operation.
+// roleAssignmentDelay returns the (short) simulated latency of a role assignment
+// operation. See blockStorageDelay for why the values are kept small.
 func roleAssignmentDelay() time.Duration {
-	const base int = 30
+	const base int = 3
 
-	variation := rand.IntN(60) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
+	variation := rand.IntN(4) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
 
 	return time.Duration(base+variation) * time.Second
 }

--- a/csp/dummy/pkg/plugin/workspace.go
+++ b/csp/dummy/pkg/plugin/workspace.go
@@ -25,10 +25,12 @@ func (w *Workspace) Delete(ctx context.Context, resource *wsdom.Workspace) error
 	return simulateWS(ctx, "delete", resource, workspaceDelay(), w.logger)
 }
 
+// workspaceDelay returns the (short) simulated latency of a workspace operation. See
+// blockStorageDelay for why the values are kept small.
 func workspaceDelay() time.Duration {
-	const base int = 15
+	const base int = 2
 
-	variation := rand.IntN(30) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
+	variation := rand.IntN(3) //#nosec G404 -- math/rand/v2 is fine here: delay jitter is not security-sensitive
 
 	return time.Duration(base+variation) * time.Second
 }

--- a/csp/dummy/test/integration/main_test.go
+++ b/csp/dummy/test/integration/main_test.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	testNamespace = "ecp-dummy-delegator"
-	pollInterval  = 5 * time.Second
+	pollInterval  = 2 * time.Second
 	timeout       = 2 * time.Minute
 	// dependencyTimeout allows for resources that must wait on a dependency to
 	// become active before they themselves can be reconciled (two sequential

--- a/doc/PLUGINS.md
+++ b/doc/PLUGINS.md
@@ -110,21 +110,26 @@ Direct CSP adapter for Aruba Cloud, without a Crossplane layer.
 
 A multi-component test harness that tests the full ECP stack (gateway + plugin) end-to-end on a KIND cluster. Components are auto-discovered from the `build/` directory.
 
+There are three integration suites, each self-contained. Every `kind-deploy-<component>` target also deploys the fixtures/components its suite needs, so it is a complete setup for the matching `kind-test-<component>` target:
+
+- **`gateway-regional`** and **`gateway-global`** test only the gateway's REST↔CR translation (create/read/update/delete through the API, asserting HTTP responses — never reconciled status). Each needs only its own gateway plus `test-data`; not the other gateway, and not the delegator.
+- **`delegator`** tests reconciliation: the dummy-plugin controllers drive CRs to `Active`. It needs `test-data`.
+
 ```bash
-# Start KIND cluster, load all images, deploy all components
+# Start the KIND cluster and build + load the images
 make -C test/e2e kind-start
-
-# Build all component images
 make -C test/e2e build-all
+make -C test/e2e kind-load-all
 
-# Run all tests
-make -C test/e2e test-all
+# Deploy a suite's components and run it (deploy pulls in the fixtures it needs)
+make -C test/e2e kind-deploy-gateway-regional
+make -C test/e2e kind-test-gateway-regional
 
 # Tear down
 make -C test/e2e kind-stop
 ```
 
-The e2e module (`test/e2e`) is excluded from the standard per-module CI checks (`GO_MODULES_EXCLUDE` in `.common.mk`).
+See `test/e2e/README.md` for the full per-suite dependency table. The e2e module (`test/e2e`) is excluded from the standard per-module CI checks (`GO_MODULES_EXCLUDE` in `.common.mk`).
 
 ## Writing a New Plugin
 

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -119,17 +119,18 @@ $(foreach comp,$(DEPLOYMENTS),$(eval $(call kind_deploy_rule,$(comp))))
 #   * test-data        — tenant namespace + storage SKUs + regions (leaf fixture);
 #                        the tenant namespace is where workspace/role CRs are created.
 #   * delegator        — reconciles CRs to Active (dummy plugin); needs test-data.
-#   * gateway-regional — needs the delegator (reconcile) and test-data (tenant
-#                        namespace + SKUs). It does NOT need the global gateway.
+#   * gateway-regional — a pure REST↔CR gateway suite; needs only test-data (tenant
+#                        namespace + SKUs). It never waits for reconciliation, so it
+#                        needs neither the delegator nor the global gateway.
 #   * gateway-global   — needs test-data (regions to list, tenant namespace for roles).
 # These add-only prerequisite lines augment the recipes generated above; make merges
 # duplicate prerequisites, so test-data is applied once per invocation.
 deploy-delegator: deploy-test-data
-deploy-gateway-regional: deploy-delegator deploy-test-data
+deploy-gateway-regional: deploy-test-data
 deploy-gateway-global: deploy-test-data
 
 kind-deploy-delegator: kind-deploy-test-data
-kind-deploy-gateway-regional: kind-deploy-delegator kind-deploy-test-data
+kind-deploy-gateway-regional: kind-deploy-test-data
 kind-deploy-gateway-global: kind-deploy-test-data
 
 # =====================================================================================

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -112,6 +112,26 @@ kind-deploy-$(1): ## Deploy a specific deployment to the KIND cluster (e.g., mak
 endef
 $(foreach comp,$(DEPLOYMENTS),$(eval $(call kind_deploy_rule,$(comp))))
 
+# --- Test-suite deployment dependencies ----------------------------------------
+# Deploying a component that has an integration suite also deploys every other
+# component that suite needs, so `make [kind-]deploy-<comp>` is a complete setup for
+# `make [kind-]test-<comp>`. Dependencies (see test/integration/<comp>):
+#   * test-data        — tenant namespace + storage SKUs + regions (leaf fixture);
+#                        the tenant namespace is where workspace/role CRs are created.
+#   * delegator        — reconciles CRs to Active (dummy plugin); needs test-data.
+#   * gateway-regional — needs the delegator (reconcile) and test-data (tenant
+#                        namespace + SKUs). It does NOT need the global gateway.
+#   * gateway-global   — needs test-data (regions to list, tenant namespace for roles).
+# These add-only prerequisite lines augment the recipes generated above; make merges
+# duplicate prerequisites, so test-data is applied once per invocation.
+deploy-delegator: deploy-test-data
+deploy-gateway-regional: deploy-delegator deploy-test-data
+deploy-gateway-global: deploy-test-data
+
+kind-deploy-delegator: kind-deploy-test-data
+kind-deploy-gateway-regional: kind-deploy-delegator kind-deploy-test-data
+kind-deploy-gateway-global: kind-deploy-test-data
+
 # =====================================================================================
 # Cleanup
 # =====================================================================================

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -102,6 +102,31 @@ If you have a running cluster with the components deployed, you can run the test
     make test-delegator
     ```
 
+### Gateway test suites
+
+Alongside the `delegator` suite, there are two gateway suites, each targeting a
+single gateway. Every suite is independent and only needs the components it talks
+to deployed:
+
+| Suite | Command | Requires deployed |
+|-------|---------|-------------------|
+| `delegator` | `make kind-test-delegator` | `delegator` |
+| `gateway-regional` | `make kind-test-gateway-regional` | `delegator`, `gateway-regional`, `test-data` |
+| `gateway-global` | `make kind-test-gateway-global` | `gateway-global`, `test-data` |
+
+The `gateway-regional` suite exercises only the regional gateway (storage, block
+storage, image, workspace). Region listing/lookup is a global concern covered by
+the `gateway-global` suite, so **the regional suite does not require the global
+gateway** — deploy just `delegator`, `gateway-regional`, and `test-data` to run it:
+
+```shell
+make kind-deploy-delegator kind-deploy-gateway-regional kind-deploy-test-data
+make kind-test-gateway-regional
+```
+
+`kind-deploy-all` deploys every component, which is convenient when running more
+than one suite.
+
 ### Cleaning Up
 
 To clean up resources from the KIND cluster without destroying the cluster itself:

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -105,27 +105,27 @@ If you have a running cluster with the components deployed, you can run the test
 ### Gateway test suites
 
 Alongside the `delegator` suite, there are two gateway suites, each targeting a
-single gateway. Every suite is independent and only needs the components it talks
-to deployed:
+single gateway. Each `[kind-]deploy-<component>` target also deploys everything that
+component's suite needs, so it is a complete setup for the matching test target:
 
-| Suite | Command | Requires deployed |
-|-------|---------|-------------------|
-| `delegator` | `make kind-test-delegator` | `delegator` |
-| `gateway-regional` | `make kind-test-gateway-regional` | `delegator`, `gateway-regional`, `test-data` |
-| `gateway-global` | `make kind-test-gateway-global` | `gateway-global`, `test-data` |
+| Suite | Deploy + test | Also deploys |
+|-------|---------------|--------------|
+| `delegator` | `make kind-deploy-delegator && make kind-test-delegator` | `test-data` |
+| `gateway-regional` | `make kind-deploy-gateway-regional && make kind-test-gateway-regional` | `delegator`, `test-data` |
+| `gateway-global` | `make kind-deploy-gateway-global && make kind-test-gateway-global` | `test-data` |
+
+`test-data` provides the tenant namespace (where workspace and role CRs are created),
+the storage SKUs, and the regions. The `delegator` reconciles CRs to `Active` with
+its dummy plugin.
 
 The `gateway-regional` suite exercises only the regional gateway (storage, block
-storage, image, workspace). Region listing/lookup is a global concern covered by
-the `gateway-global` suite, so **the regional suite does not require the global
-gateway** — deploy just `delegator`, `gateway-regional`, and `test-data` to run it:
+storage, image, workspace). Region listing/lookup is a global concern covered by the
+`gateway-global` suite, so **the regional suite does not require the global gateway**
+— `kind-deploy-gateway-regional` brings up `delegator`, `test-data`, and
+`gateway-regional`, but not `gateway-global`.
 
-```shell
-make kind-deploy-delegator kind-deploy-gateway-regional kind-deploy-test-data
-make kind-test-gateway-regional
-```
-
-`kind-deploy-all` deploys every component, which is convenient when running more
-than one suite.
+`kind-deploy-all` deploys every component, which is convenient when running more than
+one suite.
 
 ### Cleaning Up
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -111,18 +111,20 @@ component's suite needs, so it is a complete setup for the matching test target:
 | Suite | Deploy + test | Also deploys |
 |-------|---------------|--------------|
 | `delegator` | `make kind-deploy-delegator && make kind-test-delegator` | `test-data` |
-| `gateway-regional` | `make kind-deploy-gateway-regional && make kind-test-gateway-regional` | `delegator`, `test-data` |
+| `gateway-regional` | `make kind-deploy-gateway-regional && make kind-test-gateway-regional` | `test-data` |
 | `gateway-global` | `make kind-deploy-gateway-global && make kind-test-gateway-global` | `test-data` |
 
-`test-data` provides the tenant namespace (where workspace and role CRs are created),
-the storage SKUs, and the regions. The `delegator` reconciles CRs to `Active` with
-its dummy plugin.
+`test-data` provides the tenant namespace (where workspace/role/storage CRs are
+created), the storage SKUs, and the regions. The `delegator` reconciles CRs to
+`Active` with its dummy plugin.
 
-The `gateway-regional` suite exercises only the regional gateway (storage, block
-storage, image, workspace). Region listing/lookup is a global concern covered by the
-`gateway-global` suite, so **the regional suite does not require the global gateway**
-— `kind-deploy-gateway-regional` brings up `delegator`, `test-data`, and
-`gateway-regional`, but not `gateway-global`.
+The two gateway suites test only the REST↔CR translation of their gateway: they
+create/read/update/delete resources through the API and assert the HTTP responses,
+never the reconciled status. Reconciliation to `Active` is exercised separately by
+the `delegator` suite. Because of that, **the gateway suites need neither each other
+nor the delegator** — each runs against just its own gateway plus `test-data`. In
+particular, the `gateway-regional` suite does not require the global gateway or the
+delegator.
 
 `kind-deploy-all` deploys every component, which is convenient when running more than
 one suite.

--- a/test/e2e/test/integration/delegator/main_test.go
+++ b/test/e2e/test/integration/delegator/main_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	pollInterval  = 10 * time.Second
+	pollInterval  = 2 * time.Second
 	timeout       = 5 * time.Minute
 	testTenant    = "test-tenant"
 	testWorkspace = "test-workspace"

--- a/test/e2e/test/integration/gateway-regional/blockstorage_test.go
+++ b/test/e2e/test/integration/gateway-regional/blockstorage_test.go
@@ -3,32 +3,18 @@
 package integration
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
-
-	k8sadapter "github.com/eu-sovereign-cloud/ecp/framework/backend/kubernetes"
-	resource "github.com/eu-sovereign-cloud/ecp/framework/kernel/resource"
-	commondomain "github.com/eu-sovereign-cloud/ecp/resource/common/domain"
-	bsdom "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/block-storage"
-	bsk8s "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/block-storage/backend/kubernetes"
 )
 
-// newBlockStorageBody is a helper to construct the body for creating/updating block storage.
-func newBlockStorageBody(t *testing.T, sizeGB int) schema.BlockStorage {
-	t.Helper()
-
+// newBlockStorageBody builds the request body for creating/updating a block storage.
+func newBlockStorageBody(sizeGB int) schema.BlockStorage {
 	return schema.BlockStorage{
 		Spec: schema.BlockStorageSpec{
 			SizeGB: sizeGB,
@@ -37,194 +23,79 @@ func newBlockStorageBody(t *testing.T, sizeGB int) schema.BlockStorage {
 	}
 }
 
+// TestBlockStorageAPI exercises the regional gateway's block storage REST handler.
+// Create, read-back, update, and delete are verified purely through the gateway's
+// HTTP responses; reconciliation to Active is the delegator's responsibility and is
+// covered by the delegator suite, so this suite needs no reconciler.
 func TestBlockStorageAPI(t *testing.T) {
-	// t.Parallel()
-
-	t.Run("should create a block storage resource via the gateway API", func(t *testing.T) {
-		// t.Parallel()
-
+	t.Run("should create and retrieve a block storage resource via the gateway API", func(t *testing.T) {
 		//
-		// Given a unique block storage resource definition
+		// Given a unique block storage name
 		resourceName := "test-bs-create-" + uuid.New().String()[:8]
-		blockStorageBody := newBlockStorageBody(t, 1)
-		body, err := json.Marshal(blockStorageBody)
+
+		//
+		// When we create it through the gateway
+		createResp, err := storageClient.CreateOrUpdateBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil, newBlockStorageBody(1))
 		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
 
 		//
-		// When we call the CreateOrUpdateBlockStorage method
-		resp, err := storageClient.CreateOrUpdateBlockStorageWithBody(context.Background(), testTenant, testWorkspace, resourceName, nil, "application/json", bytes.NewReader(body))
+		// Then it can be read back with the spec we sent
+		getResp, err := storageClient.GetBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName)
 		require.NoError(t, err)
-		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.NotNil(t, getResp.JSON200.Metadata)
+		require.Equal(t, resourceName, getResp.JSON200.Metadata.Name)
+		require.Equal(t, 1, getResp.JSON200.Spec.SizeGB)
+		require.Equal(t, "sku-1", getResp.JSON200.Spec.SkuRef.Resource)
 
 		//
-		// Then the API call should return a success status
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-
-		//
-		// And the block storage custom resource should eventually become active in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdBS bsk8s.BlockStorage
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant, Workspace: testWorkspace})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-
-			if err := k8sClient.Get(ctx, key, &createdBS); err != nil {
-				return false, nil // Keep retrying
-			}
-
-			if createdBS.Status != nil && commondomain.ResourceState(createdBS.Status.State) == commondomain.ResourceStateActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "block storage CR should become active")
-
-		//
-		// And we can cleanup the block storage
-		bsDomain := &bsdom.BlockStorage{
-			RegionalMetadata: commondomain.RegionalMetadata{
-				CommonMetadata: commondomain.CommonMetadata{
-					Name: resourceName,
-				},
-				Scope: resource.Scope{
-					Tenant:    testTenant,
-					Workspace: testWorkspace,
-				},
-			},
-		}
-
-		err = blockStorageRepo.Delete(t.Context(), bsDomain)
+		// And it can be deleted
+		delResp, err := storageClient.DeleteBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil)
 		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
+	})
+
+	t.Run("should update a block storage resource's size via the gateway API", func(t *testing.T) {
+		//
+		// Given a block storage created at 1GB
+		resourceName := "test-bs-update-" + uuid.New().String()[:8]
+		createResp, err := storageClient.CreateOrUpdateBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil, newBlockStorageBody(1))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
+
+		//
+		// When we update its size to 2GB through the gateway
+		updateResp, err := storageClient.CreateOrUpdateBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil, newBlockStorageBody(2))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, updateResp.StatusCode())
+
+		//
+		// Then the stored spec reflects the new size
+		getResp, err := storageClient.GetBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.Equal(t, 2, getResp.JSON200.Spec.SizeGB)
+
+		delResp, err := storageClient.DeleteBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
 
 	t.Run("should delete a block storage resource via the gateway API", func(t *testing.T) {
-		// t.Parallel()
-
 		//
-		// Given a unique block storage resource that has been created
+		// Given a block storage that has been created
 		resourceName := "test-bs-delete-" + uuid.New().String()[:8]
-		blockStorageBody := newBlockStorageBody(t, 1)
-		createBody, err := json.Marshal(blockStorageBody)
+		createResp, err := storageClient.CreateOrUpdateBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil, newBlockStorageBody(1))
 		require.NoError(t, err)
-
-		createResp, err := storageClient.CreateOrUpdateBlockStorageWithBody(context.Background(), testTenant, testWorkspace, resourceName, nil, "application/json", bytes.NewReader(createBody))
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, createResp.StatusCode)
-		_ = createResp.Body.Close()
-
-		// And the resource is active in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdBS bsk8s.BlockStorage
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant, Workspace: testWorkspace})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-			if err := k8sClient.Get(ctx, key, &createdBS); err != nil {
-				return false, nil
-			}
-			if createdBS.Status != nil && commondomain.ResourceState(createdBS.Status.State) == commondomain.ResourceStateActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "block storage CR should become active before deletion")
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
 
 		//
-		// When we call DeleteBlockStorage on the SDK client
-		delResp, err := storageClient.DeleteBlockStorage(context.Background(), testTenant, testWorkspace, resourceName, nil)
+		// When we delete it, the gateway accepts the request
+		delResp, err := storageClient.DeleteBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, resourceName, nil)
 		require.NoError(t, err)
-		_ = delResp.Body.Close()
-
-		//
-		// Then the API call should return a success status
-		require.Equal(t, http.StatusAccepted, delResp.StatusCode)
-
-		// And the block storage custom resource should eventually be removed
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout+2*time.Minute, true, func(ctx context.Context) (bool, error) {
-			var createdBS bsk8s.BlockStorage
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant, Workspace: testWorkspace})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-			if err := k8sClient.Get(ctx, key, &createdBS); err != nil {
-				if kerrors.IsNotFound(err) {
-					return true, nil // Successfully deleted
-				}
-
-				return false, err // Other error
-			}
-			return false, nil // Not deleted yet
-		})
-		require.NoError(t, err, "block storage CR should be deleted")
-	})
-
-	t.Run("should increase the size of a block storage resource via the gateway API", func(t *testing.T) {
-		// t.Parallel()
-
-		//
-		// Given a unique block storage resource that is active with a size of 1GB
-		resourceName := "test-bs-increase-" + uuid.New().String()[:8]
-		blockStorageBody := newBlockStorageBody(t, 1)
-		createBody, err := json.Marshal(blockStorageBody)
-		require.NoError(t, err)
-
-		createResp, err := storageClient.CreateOrUpdateBlockStorageWithBody(context.Background(), testTenant, testWorkspace, resourceName, nil, "application/json", bytes.NewReader(createBody))
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, createResp.StatusCode)
-		_ = createResp.Body.Close()
-
-		var createdBS bsk8s.BlockStorage
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant, Workspace: testWorkspace})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-			if err := k8sClient.Get(ctx, key, &createdBS); err != nil {
-				return false, nil
-			}
-			if createdBS.Status != nil && commondomain.ResourceState(createdBS.Status.State) == commondomain.ResourceStateActive && createdBS.Status.SizeGB == 1 {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "block storage CR should be active with initial size")
-
-		//
-		// When we update the resource with an increased size of 2GB
-		updateBodyPayload := newBlockStorageBody(t, 2)
-		updateBody, err := json.Marshal(updateBodyPayload)
-		require.NoError(t, err)
-
-		updateResp, err := storageClient.CreateOrUpdateBlockStorageWithBody(context.Background(), testTenant, testWorkspace, resourceName, nil, "application/json", bytes.NewReader(updateBody))
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, updateResp.StatusCode)
-		_ = updateResp.Body.Close()
-
-		//
-		// Then the resource status should eventually reflect the new size of 2GB.
-		// The resize operation simulates roughly twice the base delay, so allow the longer timeout.
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, resizeTimeout, true, func(ctx context.Context) (bool, error) {
-			var currentBS bsk8s.BlockStorage
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant, Workspace: testWorkspace})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-			if err := k8sClient.Get(ctx, key, &currentBS); err != nil {
-				return false, nil
-			}
-			if currentBS.Status != nil && commondomain.ResourceState(currentBS.Status.State) == commondomain.ResourceStateActive && currentBS.Status.SizeGB == 2 {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "block storage CR should have its size increased to 2GB")
-
-		//
-		// And we can cleanup the block storage
-		bsDomain := &bsdom.BlockStorage{
-			RegionalMetadata: commondomain.RegionalMetadata{
-				CommonMetadata: commondomain.CommonMetadata{
-					Name: resourceName,
-				},
-				Scope: resource.Scope{
-					Tenant:    testTenant,
-					Workspace: testWorkspace,
-				},
-			},
-		}
-
-		err = blockStorageRepo.Delete(t.Context(), bsDomain)
-		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
 }

--- a/test/e2e/test/integration/gateway-regional/image_test.go
+++ b/test/e2e/test/integration/gateway-regional/image_test.go
@@ -3,148 +3,74 @@
 package integration
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
-
-	k8sadapter "github.com/eu-sovereign-cloud/ecp/framework/backend/kubernetes"
-	resource "github.com/eu-sovereign-cloud/ecp/framework/kernel/resource"
-	commondomain "github.com/eu-sovereign-cloud/ecp/resource/common/domain"
-	imgdom "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/image"
-	imgk8s "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/image/backend/kubernetes"
 )
 
-// newImageBody is a helper to construct the body for creating/updating an image.
-func newImageBody(t *testing.T, boot schema.ImageSpecBoot) schema.Image {
-	t.Helper()
-
+// newImageBody builds the request body for creating an image. It references the
+// workspace-scoped source block storage that TestMain provisions.
+func newImageBody() schema.Image {
 	return schema.Image{
 		Spec: schema.ImageSpec{
-			BlockStorageRef: schema.Reference{Resource: "block-storages/source-bs", Workspace: testWorkspace},
+			BlockStorageRef: schema.Reference{Resource: "block-storages/" + sourceBlockStorage, Workspace: testWorkspace},
 			CpuArchitecture: schema.ImageSpecCpuArchitectureAmd64,
-			Boot:            boot,
+			Boot:            schema.ImageSpecBootUEFI,
 			Initializer:     schema.ImageSpecInitializerNone,
 		},
 	}
 }
 
+// TestImageAPI exercises the regional gateway's image REST handler. Create,
+// read-back, and delete are verified through the gateway's HTTP responses;
+// reconciliation to Active is covered by the delegator suite, so this suite needs no
+// reconciler.
 func TestImageAPI(t *testing.T) {
-	t.Run("should create an image resource via the gateway API", func(t *testing.T) {
+	t.Run("should create and retrieve an image resource via the gateway API", func(t *testing.T) {
 		//
-		// Given a unique image resource definition
+		// Given a unique image name
 		resourceName := "test-img-create-" + uuid.New().String()[:8]
-		imageBody := newImageBody(t, schema.ImageSpecBootUEFI)
-		body, err := json.Marshal(imageBody)
+
+		//
+		// When we create it through the gateway
+		createResp, err := storageClient.CreateOrUpdateImageWithResponse(context.Background(), testTenant, resourceName, nil, newImageBody())
 		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
 
 		//
-		// When we call the CreateOrUpdateImage method
-		resp, err := storageClient.CreateOrUpdateImageWithBody(context.Background(), testTenant, resourceName, nil, "application/json", bytes.NewReader(body))
+		// Then it can be read back with the spec we sent
+		getResp, err := storageClient.GetImageWithResponse(context.Background(), testTenant, resourceName)
 		require.NoError(t, err)
-		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.NotNil(t, getResp.JSON200.Metadata)
+		require.Equal(t, resourceName, getResp.JSON200.Metadata.Name)
+		require.Equal(t, schema.ImageSpecCpuArchitectureAmd64, getResp.JSON200.Spec.CpuArchitecture)
 
 		//
-		// Then the API call should return a success status
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-
-		//
-		// And the image custom resource should eventually become active in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdImg imgk8s.Image
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-
-			if err := k8sClient.Get(ctx, key, &createdImg); err != nil {
-				return false, nil // Keep retrying
-			}
-
-			if createdImg.Status != nil && commondomain.ResourceState(createdImg.Status.State) == commondomain.ResourceStateActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "image CR should become active")
-
-		//
-		// And we can cleanup the image
-		imgDomain := &imgdom.Image{
-			RegionalMetadata: commondomain.RegionalMetadata{
-				CommonMetadata: commondomain.CommonMetadata{
-					Name: resourceName,
-				},
-				Scope: resource.Scope{
-					Tenant: testTenant,
-				},
-			},
-		}
-
-		err = imageRepo.Delete(t.Context(), imgDomain)
+		// And it can be deleted
+		delResp, err := storageClient.DeleteImageWithResponse(context.Background(), testTenant, resourceName, nil)
 		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
 
 	t.Run("should delete an image resource via the gateway API", func(t *testing.T) {
 		//
-		// Given a unique image resource that has been created
+		// Given an image that has been created
 		resourceName := "test-img-delete-" + uuid.New().String()[:8]
-		imageBody := newImageBody(t, schema.ImageSpecBootUEFI)
-		createBody, err := json.Marshal(imageBody)
+		createResp, err := storageClient.CreateOrUpdateImageWithResponse(context.Background(), testTenant, resourceName, nil, newImageBody())
 		require.NoError(t, err)
-
-		createResp, err := storageClient.CreateOrUpdateImageWithBody(context.Background(), testTenant, resourceName, nil, "application/json", bytes.NewReader(createBody))
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, createResp.StatusCode)
-		_ = createResp.Body.Close()
-
-		// And the resource is active in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdImg imgk8s.Image
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-			if err := k8sClient.Get(ctx, key, &createdImg); err != nil {
-				return false, nil
-			}
-			if createdImg.Status != nil && commondomain.ResourceState(createdImg.Status.State) == commondomain.ResourceStateActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "image CR should become active before deletion")
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
 
 		//
-		// When we call DeleteImage on the SDK client
-		delResp, err := storageClient.DeleteImage(context.Background(), testTenant, resourceName, nil)
+		// When we delete it, the gateway accepts the request
+		delResp, err := storageClient.DeleteImageWithResponse(context.Background(), testTenant, resourceName, nil)
 		require.NoError(t, err)
-		_ = delResp.Body.Close()
-
-		//
-		// Then the API call should return a success status
-		require.Equal(t, http.StatusAccepted, delResp.StatusCode)
-
-		// And the image custom resource should eventually be removed
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout+2*time.Minute, true, func(ctx context.Context) (bool, error) {
-			var createdImg imgk8s.Image
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant})
-			key := client.ObjectKey{Namespace: ns, Name: resourceName}
-			if err := k8sClient.Get(ctx, key, &createdImg); err != nil {
-				if kerrors.IsNotFound(err) {
-					return true, nil // Successfully deleted
-				}
-
-				return false, err // Other error
-			}
-			return false, nil // Not deleted yet
-		})
-		require.NoError(t, err, "image CR should be deleted")
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
 }

--- a/test/e2e/test/integration/gateway-regional/main_test.go
+++ b/test/e2e/test/integration/gateway-regional/main_test.go
@@ -101,6 +101,12 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to create dynamic client: %v", err)
 	}
 
+	// Initialise the logger before it is captured by the repo adapters below.
+	// The adapters store the value passed at construction time, so a nil logger
+	// here makes any adapter error path (e.g. a failed Create) panic instead of
+	// reporting the error.
+	testLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
+
 	// SECA repos setup
 	workspaceRepo = k8sadapter.NewNamespaceManagingRepoAdapter(
 		dynamicClient,
@@ -146,8 +152,6 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("Failed to create storage SDK client: %v", err)
 	}
-
-	testLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	// Provide Workspace for BlockStorage tests
 	if err := createTestWorkspace(context.Background(), workspaceRepo); err != nil {

--- a/test/e2e/test/integration/gateway-regional/main_test.go
+++ b/test/e2e/test/integration/gateway-regional/main_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/transport/spdy"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	regionv1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.region.v1"
 	storagev1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.storage.v1"
 	workspacev1sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.workspace.v1"
 
@@ -68,7 +67,6 @@ var (
 	clientset        *kubernetes.Clientset
 	dynamicClient    dynamic.Interface
 	testLogger       *slog.Logger
-	regionClient     *regionv1.ClientWithResponses
 	storageClient    *storagev1.ClientWithResponses
 	workspaceClient  *workspacev1sdk.ClientWithResponses
 	workspaceRepo    persistence.Repo[*wsdom.Workspace]
@@ -129,14 +127,9 @@ func TestMain(m *testing.M) {
 		imgk8s.ImageFromCR,
 	)
 
-	// Port forward for Global Gateway
-	globalPort, stopGlobalPF, err := startPortForward("gateway-global-svc", "app=gateway-global", restConfig)
-	if err != nil {
-		log.Fatalf("Global gateway port-forward failed: %v", err)
-	}
-	defer close(stopGlobalPF)
-
-	// Port forward for Regional Gateway
+	// Port forward for Regional Gateway. The regional suite talks only to the
+	// regional gateway; region listing/lookup is a global concern covered by the
+	// gateway-global suite, so the global gateway is intentionally not required here.
 	regionalPort, stopRegionalPF, err := startPortForward("gateway-regional-svc", "app=gateway-regional", restConfig)
 	if err != nil {
 		log.Fatalf("Regional gateway port-forward failed: %v", err)
@@ -144,12 +137,6 @@ func TestMain(m *testing.M) {
 	defer close(stopRegionalPF)
 
 	// SECA SDK clients setup
-	globalURL := fmt.Sprintf("http://localhost:%d/providers/seca.region", globalPort)
-	regionClient, err = regionv1.NewClientWithResponses(globalURL)
-	if err != nil {
-		log.Fatalf("Failed to create region SDK client: %v", err)
-	}
-
 	regionalBaseURL := fmt.Sprintf("http://localhost:%d", regionalPort)
 	workspaceClient, err = workspacev1sdk.NewClientWithResponses(regionalBaseURL + "/providers/seca.workspace")
 	if err != nil {

--- a/test/e2e/test/integration/gateway-regional/main_test.go
+++ b/test/e2e/test/integration/gateway-regional/main_test.go
@@ -4,11 +4,9 @@ package integration
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"log"
-	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
@@ -17,132 +15,58 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	storagev1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.storage.v1"
 	workspacev1sdk "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.workspace.v1"
-
-	k8sadapter "github.com/eu-sovereign-cloud/ecp/framework/backend/kubernetes"
-	kernel "github.com/eu-sovereign-cloud/ecp/framework/kernel"
-	persistence "github.com/eu-sovereign-cloud/ecp/framework/kernel/port/persistence"
-	resource "github.com/eu-sovereign-cloud/ecp/framework/kernel/resource"
-	commondomain "github.com/eu-sovereign-cloud/ecp/resource/common/domain"
-	bsdom "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/block-storage"
-	bsk8s "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/block-storage/backend/kubernetes"
-	imgdom "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/image"
-	imgk8s "github.com/eu-sovereign-cloud/ecp/resource/storage/v1/image/backend/kubernetes"
-	wsdom "github.com/eu-sovereign-cloud/ecp/resource/workspace/v1"
-	wsk8s "github.com/eu-sovereign-cloud/ecp/resource/workspace/v1/backend/kubernetes"
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
 )
 
 const (
 	pollInterval    = 5 * time.Second
 	timeout         = 3 * time.Minute
-	// resizeTimeout allows for the block storage increase-size operation, which the
-	// dummy plugin simulates at roughly twice the base delay (up to ~178s), so it
-	// needs a longer timeout than the regular create/delete polls.
-	resizeTimeout = 5 * time.Minute
 	systemNamespace = "e2e-ecp"
+	serviceName     = "gateway-regional-svc"
 	testTenant      = "test-tenant"
 	testWorkspace   = "test-workspace"
-	testRegion      = "ITBG-Bergamo"
-	// sourceBlockStorage is a workspace-scoped block storage that image tests depend
-	// on: images reference "block-storages/source-bs" and stay pending until it is
-	// active.
+	// sourceBlockStorage is a workspace-scoped block storage that image tests
+	// reference via "block-storages/source-bs". This suite does not wait for it to
+	// reconcile — it only has to exist so the image reference resolves.
 	sourceBlockStorage = "source-bs"
 )
 
 var (
-	k8sClient        client.Client
-	clientset        *kubernetes.Clientset
-	dynamicClient    dynamic.Interface
-	testLogger       *slog.Logger
-	storageClient    *storagev1.ClientWithResponses
-	workspaceClient  *workspacev1sdk.ClientWithResponses
-	workspaceRepo    persistence.Repo[*wsdom.Workspace]
-	blockStorageRepo persistence.Repo[*bsdom.BlockStorage]
-	imageRepo        persistence.Repo[*imgdom.Image]
+	clientset       *kubernetes.Clientset
+	storageClient   *storagev1.ClientWithResponses
+	workspaceClient *workspacev1sdk.ClientWithResponses
 )
 
+// TestMain wires the suite to the regional gateway alone. The regional suite
+// exercises the gateway's REST↔CR translation (create, read-back, update, delete)
+// and never inspects reconciled status. Reconciliation to Active is the delegator's
+// job and is covered by the delegator suite, so this suite needs neither the
+// delegator nor the global gateway — only the regional gateway and the test-data
+// fixtures (tenant namespace + storage SKUs).
 func TestMain(m *testing.M) {
-	var err error
-
-	// Kubernetes clients setup
-	s := runtime.NewScheme()
-	utilruntime.Must(scheme.AddToScheme(s))
-	utilruntime.Must(wsk8s.AddToScheme(s))
-	utilruntime.Must(bsk8s.AddToScheme(s))
-	utilruntime.Must(imgk8s.AddToScheme(s))
-	utilruntime.Must(corev1.AddToScheme(s))
-
 	restConfig, cs, err := setupK8sClient()
 	if err != nil {
 		log.Fatalf("Failed to set up k8s client: %v", err)
 	}
 	clientset = cs
 
-	k8sClient, err = client.New(restConfig, client.Options{Scheme: s})
-	if err != nil {
-		log.Fatalf("Failed to create controller-runtime client: %v", err)
-	}
-
-	dynamicClient, err = dynamic.NewForConfig(restConfig)
-	if err != nil {
-		log.Fatalf("Failed to create dynamic client: %v", err)
-	}
-
-	// Initialise the logger before it is captured by the repo adapters below.
-	// The adapters store the value passed at construction time, so a nil logger
-	// here makes any adapter error path (e.g. a failed Create) panic instead of
-	// reporting the error.
-	testLogger = slog.New(slog.NewTextHandler(os.Stdout, nil))
-
-	// SECA repos setup
-	workspaceRepo = k8sadapter.NewNamespaceManagingRepoAdapter(
-		dynamicClient,
-		clientset,
-		wsk8s.WorkspaceGVR,
-		testLogger,
-		wsk8s.WorkspaceToCR,
-		wsk8s.WorkspaceFromCR,
-	)
-
-	blockStorageRepo = k8sadapter.NewRepoAdapter(
-		dynamicClient,
-		bsk8s.BlockStorageGVR,
-		testLogger,
-		bsk8s.BlockStorageToCR,
-		bsk8s.BlockStorageFromCR,
-	)
-
-	imageRepo = k8sadapter.NewRepoAdapter(
-		dynamicClient,
-		imgk8s.ImageGVR,
-		testLogger,
-		imgk8s.ImageToCR,
-		imgk8s.ImageFromCR,
-	)
-
-	// Port forward for Regional Gateway. The regional suite talks only to the
-	// regional gateway; region listing/lookup is a global concern covered by the
-	// gateway-global suite, so the global gateway is intentionally not required here.
-	regionalPort, stopRegionalPF, err := startPortForward("gateway-regional-svc", "app=gateway-regional", restConfig)
+	// Port forward to the regional gateway.
+	regionalPort, stopPF, err := startPortForward(serviceName, "app=gateway-regional", restConfig)
 	if err != nil {
 		log.Fatalf("Regional gateway port-forward failed: %v", err)
 	}
-	defer close(stopRegionalPF)
+	defer close(stopPF)
 
-	// SECA SDK clients setup
+	// SECA SDK clients, both pointing at the regional gateway.
 	regionalBaseURL := fmt.Sprintf("http://localhost:%d", regionalPort)
 	workspaceClient, err = workspacev1sdk.NewClientWithResponses(regionalBaseURL + "/providers/seca.workspace")
 	if err != nil {
@@ -153,33 +77,56 @@ func TestMain(m *testing.M) {
 		log.Fatalf("Failed to create storage SDK client: %v", err)
 	}
 
-	// Provide Workspace for BlockStorage tests
-	if err := createTestWorkspace(context.Background(), workspaceRepo); err != nil {
+	// Provision shared fixtures through the gateway itself. Creating the workspace
+	// synchronously provisions its namespace (the gateway uses a namespace-managing
+	// adapter), which the block storage tests create into; the source block storage
+	// is what the image tests reference.
+	if err := ensureTestWorkspace(context.Background()); err != nil {
 		log.Fatalf("Failed to create test workspace: %v", err)
 	}
-
-	// Provide the source block storage that Image tests depend on. Images reference
-	// it with a workspace-qualified "block-storages/source-bs" reference and only
-	// become active once it is active, so it must exist and be reconciled before the
-	// suite runs. createTestWorkspace above provisions the workspace namespace it
-	// lives in.
-	if err := createSourceBlockStorage(context.Background(), blockStorageRepo); err != nil {
+	if err := ensureSourceBlockStorage(context.Background()); err != nil {
 		log.Fatalf("Failed to create source block storage: %v", err)
 	}
-	if err := waitForBlockStorageActive(context.Background(), blockStorageRepo, sourceBlockStorage); err != nil {
-		log.Fatalf("Source block storage %q did not become active: %v", sourceBlockStorage, err)
-	}
 
-	// When running the test suite
 	exitCode := m.Run()
 
-	// Cleanup fixtures. Delete the source block storage before the workspace; its
-	// deletion is blocked while any image still references it, so image tests must
-	// have cleaned up their own images by now.
-	cleanupSourceBlockStorage(context.Background(), blockStorageRepo)
-	cleanupTestWorkspace(context.Background(), workspaceRepo)
+	// Best-effort cleanup of the shared fixtures.
+	_, _ = storageClient.DeleteBlockStorageWithResponse(context.Background(), testTenant, testWorkspace, sourceBlockStorage, nil)
+	_, _ = workspaceClient.DeleteWorkspaceWithResponse(context.Background(), testTenant, testWorkspace, nil)
 
 	os.Exit(exitCode)
+}
+
+// ensureTestWorkspace creates the shared test workspace through the gateway. The
+// create is an upsert, so it tolerates a leftover fixture from a previous run.
+func ensureTestWorkspace(ctx context.Context) error {
+	resp, err := workspaceClient.CreateOrUpdateWorkspaceWithResponse(ctx, testTenant, testWorkspace, nil, schema.Workspace{})
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("unexpected status %d creating workspace %q", resp.StatusCode(), testWorkspace)
+	}
+	return nil
+}
+
+// ensureSourceBlockStorage creates the workspace-scoped source block storage that
+// image tests reference. The create is an upsert, so it tolerates a leftover fixture.
+func ensureSourceBlockStorage(ctx context.Context) error {
+	body := schema.BlockStorage{
+		Spec: schema.BlockStorageSpec{
+			SizeGB: 1,
+			SkuRef: schema.Reference{Resource: "sku-1"},
+		},
+	}
+	resp, err := storageClient.CreateOrUpdateBlockStorageWithResponse(ctx, testTenant, testWorkspace, sourceBlockStorage, nil, body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode() != http.StatusOK {
+		return fmt.Errorf("unexpected status %d creating source block storage %q", resp.StatusCode(), sourceBlockStorage)
+	}
+	return nil
 }
 
 func startPortForward(serviceName, labelSelector string, config *rest.Config) (uint16, chan struct{}, error) {
@@ -258,100 +205,4 @@ func setupPortForward(clientset *kubernetes.Clientset, config *rest.Config, serv
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, reqURL)
 	ports := []string{"0:8080"}
 	return portforward.New(dialer, ports, stopCh, readyCh, io.Discard, io.Discard)
-}
-
-func createTestWorkspace(ctx context.Context, workspaceRepo persistence.Repo[*wsdom.Workspace]) error {
-	wsDomain := &wsdom.Workspace{
-		RegionalMetadata: commondomain.RegionalMetadata{
-			CommonMetadata: commondomain.CommonMetadata{
-				Name: testWorkspace,
-			},
-			Scope: resource.Scope{
-				Tenant: testTenant,
-			},
-		},
-	}
-
-	// Tolerate a leftover fixture from a previously interrupted run (e.g. a test
-	// timeout that skipped teardown) so the suite is not permanently wedged.
-	if _, err := workspaceRepo.Create(ctx, wsDomain); err != nil && !errors.Is(err, kernel.ErrAlreadyExists) {
-		return err
-	}
-	return nil
-}
-
-func cleanupTestWorkspace(ctx context.Context, workspaceRepo persistence.Repo[*wsdom.Workspace]) error {
-	wsDomain := &wsdom.Workspace{
-		RegionalMetadata: commondomain.RegionalMetadata{
-			CommonMetadata: commondomain.CommonMetadata{
-				Name: testWorkspace,
-			},
-			Scope: resource.Scope{
-				Tenant: testTenant,
-			},
-		},
-	}
-
-	err := workspaceRepo.Delete(ctx, wsDomain)
-
-	return err
-}
-
-// newSourceBlockStorage builds the workspace-scoped block storage that image tests
-// depend on. It lives in the test workspace; image resources reference it with a
-// workspace-qualified "block-storages/source-bs" reference.
-func newSourceBlockStorage() *bsdom.BlockStorage {
-	return &bsdom.BlockStorage{
-		RegionalMetadata: commondomain.RegionalMetadata{
-			CommonMetadata: commondomain.CommonMetadata{
-				Name: sourceBlockStorage,
-			},
-			Scope: resource.Scope{
-				Tenant:    testTenant,
-				Workspace: testWorkspace,
-			},
-		},
-		Spec: bsdom.BlockStorageSpec{
-			SizeGB: 1,
-			SkuRef: commondomain.Reference{
-				Region:   testRegion,
-				Resource: "sku-1",
-			},
-		},
-	}
-}
-
-func createSourceBlockStorage(ctx context.Context, repo persistence.Repo[*bsdom.BlockStorage]) error {
-	// Tolerate a leftover fixture from a previously interrupted run so the suite is
-	// not permanently wedged; waitForBlockStorageActive still ensures it is ready.
-	if _, err := repo.Create(ctx, newSourceBlockStorage()); err != nil && !errors.Is(err, kernel.ErrAlreadyExists) {
-		return err
-	}
-	return nil
-}
-
-func cleanupSourceBlockStorage(ctx context.Context, repo persistence.Repo[*bsdom.BlockStorage]) error {
-	return repo.Delete(ctx, newSourceBlockStorage())
-}
-
-// waitForBlockStorageActive polls until the named workspace-scoped block storage
-// reports an active state.
-func waitForBlockStorageActive(ctx context.Context, repo persistence.Repo[*bsdom.BlockStorage], name string) error {
-	return wait.PollUntilContextTimeout(ctx, pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-		loaded := &bsdom.BlockStorage{
-			RegionalMetadata: commondomain.RegionalMetadata{
-				CommonMetadata: commondomain.CommonMetadata{
-					Name: name,
-				},
-				Scope: resource.Scope{
-					Tenant:    testTenant,
-					Workspace: testWorkspace,
-				},
-			},
-		}
-		if err := repo.Load(ctx, &loaded); err != nil {
-			return false, nil
-		}
-		return loaded.Status != nil && loaded.Status.State == commondomain.ResourceStateActive, nil
-	})
 }

--- a/test/e2e/test/integration/gateway-regional/workspace_test.go
+++ b/test/e2e/test/integration/gateway-regional/workspace_test.go
@@ -3,140 +3,60 @@
 package integration
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	kerrs "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
-
-	k8sadapter "github.com/eu-sovereign-cloud/ecp/framework/backend/kubernetes"
-	resource "github.com/eu-sovereign-cloud/ecp/framework/kernel/resource"
-	commondomain "github.com/eu-sovereign-cloud/ecp/resource/common/domain"
-	wsdom "github.com/eu-sovereign-cloud/ecp/resource/workspace/v1"
-	wsk8s "github.com/eu-sovereign-cloud/ecp/resource/workspace/v1/backend/kubernetes"
 )
 
+// TestWorkspaceAPI exercises the regional gateway's workspace REST handler. Create,
+// read-back, and delete are verified through the gateway's HTTP responses;
+// reconciliation to Active is covered by the delegator suite, so this suite needs no
+// reconciler.
 func TestWorkspaceAPI(t *testing.T) {
-	// t.Parallel()
-
-	t.Run("should create a workspace resource via the gateway API", func(t *testing.T) {
-		// t.Parallel()
-
+	t.Run("should create and retrieve a workspace resource via the gateway API", func(t *testing.T) {
 		//
-		// Given a unique workspace name and an empty request body
+		// Given a unique workspace name
 		workspaceName := "test-ws-create-" + uuid.New().String()[:8]
-		body, err := json.Marshal(schema.Workspace{})
+
+		//
+		// When we create it through the gateway
+		createResp, err := workspaceClient.CreateOrUpdateWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil, schema.Workspace{})
 		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
 
 		//
-		// When we call CreateOrUpdateWorkspace on the SDK client
-		resp, err := workspaceClient.CreateOrUpdateWorkspaceWithBody(context.Background(), testTenant, workspaceName, nil, "application/json", bytes.NewReader(body))
+		// Then it can be read back
+		getResp, err := workspaceClient.GetWorkspaceWithResponse(context.Background(), testTenant, workspaceName)
 		require.NoError(t, err)
-		_ = resp.Body.Close()
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.NotNil(t, getResp.JSON200.Metadata)
+		require.Equal(t, workspaceName, getResp.JSON200.Metadata.Name)
 
 		//
-		// Then the API call should return a success status
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-
-		//
-		// And the workspace custom resource should eventually become active in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdWorkspace wsk8s.Workspace
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant})
-			key := client.ObjectKey{
-				Namespace: ns,
-				Name:      workspaceName,
-			}
-			if err := k8sClient.Get(ctx, key, &createdWorkspace); err != nil {
-				return false, nil // Keep retrying if not found
-			}
-
-			if createdWorkspace.Status != nil && commondomain.ResourceState(createdWorkspace.Status.State) == commondomain.ResourceStateActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "workspace CR should become active")
-
-		//
-		// And we can cleanup the workspace
-		wsDomain := &wsdom.Workspace{
-			RegionalMetadata: commondomain.RegionalMetadata{
-				CommonMetadata: commondomain.CommonMetadata{
-					Name: workspaceName,
-				},
-				Scope: resource.Scope{
-					Tenant: testTenant,
-				},
-			},
-		}
-
-		err = workspaceRepo.Delete(t.Context(), wsDomain)
+		// And it can be deleted
+		delResp, err := workspaceClient.DeleteWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil)
 		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
 
 	t.Run("should delete a workspace resource via the gateway API", func(t *testing.T) {
-		// t.Parallel()
-
 		//
-		// Given a unique workspace that has been created
+		// Given a workspace that has been created
 		workspaceName := "test-ws-delete-" + uuid.New().String()[:8]
-		createBody, err := json.Marshal(schema.Workspace{})
+		createResp, err := workspaceClient.CreateOrUpdateWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil, schema.Workspace{})
 		require.NoError(t, err)
-		createResp, err := workspaceClient.CreateOrUpdateWorkspaceWithBody(context.Background(), testTenant, workspaceName, nil, "application/json", bytes.NewReader(createBody))
-		require.NoError(t, err)
-		require.Equal(t, http.StatusOK, createResp.StatusCode)
-		_ = createResp.Body.Close()
-
-		// And the resource is active in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdWorkspace wsk8s.Workspace
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant})
-			key := client.ObjectKey{Namespace: ns, Name: workspaceName}
-			if err := k8sClient.Get(ctx, key, &createdWorkspace); err != nil {
-				return false, nil
-			}
-			if createdWorkspace.Status != nil && commondomain.ResourceState(createdWorkspace.Status.State) == commondomain.ResourceStateActive {
-				return true, nil
-			}
-			return false, nil
-		})
-		require.NoError(t, err, "workspace CR should become active before deletion")
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
 
 		//
-		// When we call DeleteWorkspace on the SDK client
-		delResp, err := workspaceClient.DeleteWorkspace(context.Background(), testTenant, workspaceName, nil)
+		// When we delete it, the gateway accepts the request
+		delResp, err := workspaceClient.DeleteWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil)
 		require.NoError(t, err)
-		_ = delResp.Body.Close()
-
-		//
-		// Then the API call should return a success status
-		require.Equal(t, http.StatusAccepted, delResp.StatusCode)
-
-		//
-		// And the workspace custom resource should eventually be marked for deletion in the cluster
-		err = wait.PollUntilContextTimeout(t.Context(), pollInterval, timeout, true, func(ctx context.Context) (bool, error) {
-			var createdWorkspace wsk8s.Workspace
-			ns := k8sadapter.ComputeNamespace(&resource.Scope{Tenant: testTenant})
-			key := client.ObjectKey{Namespace: ns, Name: workspaceName}
-			if err := k8sClient.Get(ctx, key, &createdWorkspace); err != nil {
-				if kerrs.IsNotFound(err) {
-					return true, nil
-				}
-
-				return false, err
-			}
-
-			return false, nil
-		})
-		require.NoError(t, err, "workspace CR should have a deletion timestamp")
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
 }


### PR DESCRIPTION
Makes the e2e integration suites independent and fast.

## 1. `gateway-regional` is now a standalone gateway suite

It previously required both the **global gateway** (via an unused `regionClient` +
port-forward whose `log.Fatalf` forced a deployment) and the **delegator** (every test
polled the CR until `.Status.State == Active` — a status only the reconciler produces).

- Rewrote the suite to test only the gateway's REST↔CR translation: create → read-back
  (`Get…WithResponse`) → update → delete, asserting HTTP responses and returned spec,
  never reconciled status (same shape as the `gateway-global` roles test). Fixtures are
  provisioned **through the gateway** in `TestMain`, so the suite builds no Kubernetes
  repo/controller-runtime client.
- Reconciliation to `Active` (create/delete/increase-size) is already covered by the
  `delegator` suite, so the status polling was redundant and was removed.
- Result: the regional suite runs with **no delegator and no global gateway** in ~4s
  (was ~9 min).

## 2. Self-sufficient deploy targets

`[kind-]deploy-<component>` now also deploys everything that component's suite needs, so
it is a complete setup for `[kind-]test-<component>`:
- `delegator` → `test-data`
- `gateway-regional` → `test-data`
- `gateway-global` → `test-data`

## 3. Faster `delegator` suite (dummy plugin)

The dummy plugin simulates cloud latency by stamping `expiration = now + delay` and
returning `ErrStillProcessing` until it passes. The delays were long (30–89s per op,
60–178s for block-storage increase-size — the latter could exceed the poll timeout and
was ~50% flaky). Since the e2e delegator requeues every 1s, time-to-active ≈ delay.

- Shortened the delays to a few seconds (block-storage/image/role-assignment/network
  `3 + rand(4)`s, workspace `2 + rand(3)`s, role `1 + rand(2)`s; increase-size doubles).
  They still outlast the 1s requeue, so the pending→active lifecycle is exercised.
- Lowered the delegator (10s→2s) and csp/dummy (5s→2s) suite poll intervals so the
  shorter delays translate into faster detection.
- Result: the `delegator` suite dropped from **~650s to ~63s** (measured on kind), and
  the increase-size flakiness is gone.

## Verification

- `make pre-commit-ctzd` / `make pre-merge-ctzd BUILDER_SOURCE=local` pass (46/46 stages;
  includes lint/gosec/test of `csp/dummy`).
- On fresh KIND clusters, each deploy target was driven on its own and its suite passed:
  - `kind-deploy-gateway-regional` → `test-data` + `gateway-regional` only (no delegator);
    suite passes in ~4s.
  - `kind-deploy-gateway-global` → `test-data` + `gateway-global`; suite passes.
  - `kind-deploy-delegator` → `test-data` + `delegator`; suite passes in ~63s (this is
    where create→Active / delete / increase-size reconciliation is covered).
