### PR TITLE
chore: bump Go toolchain to 1.26.5 (fixes crypto/tls CVE GO-2026-5856)

### DIFF
--- a/.config.mk
+++ b/.config.mk
@@ -10,7 +10,7 @@ VERSION?=v0.1.0-alpha1-preview
 ###############################################################################
 
 # Go & toolchain version
-GO_VERSION?=1.26.4
+GO_VERSION?=1.26.5
 
 # Builder base image
 BUILDER_BASE_REGISTRY?=docker.io

--- a/ci/tools/go/go.mod
+++ b/ci/tools/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/ci/tools/go
 
-go 1.26.4
+go 1.26.5
 
 tool (
 	github.com/golangci/golangci-lint/v2/cmd/golangci-lint

--- a/csp/aruba/go.mod
+++ b/csp/aruba/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/csp/aruba
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Arubacloud/arubacloud-resource-operator v1.0.0

--- a/csp/dummy/go.mod
+++ b/csp/dummy/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/csp/dummy
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/eu-sovereign-cloud/ecp/framework v0.0.1

--- a/csp/ionos/go.mod
+++ b/csp/ionos/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/csp/ionos
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0

--- a/framework/go.mod
+++ b/framework/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/framework
 
-go 1.26.4
+go 1.26.5
 
 tool sigs.k8s.io/controller-tools/cmd/controller-gen
 

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/gateway
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/eu-sovereign-cloud/ecp/framework v0.0.1

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.4
+go 1.26.5
 
 use (
 	./ci/tools/go

--- a/resource/go.mod
+++ b/resource/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/resource
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/eu-sovereign-cloud/ecp/framework v0.0.1

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/eu-sovereign-cloud/ecp/test/e2e
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/Arubacloud/arubacloud-resource-operator v1.0.0


### PR DESCRIPTION
## What

Bump Go to **1.26.5** across the repo:
- `GO_VERSION` 1.26.4 → 1.26.5 in `.config.mk` (builder / tools / dev image toolchain).
- The `go` directive 1.26.4 → 1.26.5 in `go.work` and every first-party `go.mod`
  (framework, resource, gateway, csp/{aruba,dummy,ionos}, test/e2e, ci/tools/go).

## Why

`make vuln` (govulncheck) fails on **GO-2026-5856** — "Invoking Encrypted Client
Hello privacy leak in `crypto/tls`", present in the standard library at
`crypto/tls@go1.26.4` and **fixed in go1.26.5**. It's reached transitively by any
TLS-using module, so the per-module `*-vuln` gate trips (first on `csp/aruba`) and
blocks `pre-commit` / `pre-merge` on `main` today. This is a toolchain/stdlib CVE,
independent of any application code.

## Verification

With the 1.26.5 toolchain, `govulncheck ./...` on `csp/aruba` reports
**"No vulnerabilities found."** (exit 0); `go work sync` and module builds pass.