### PR TITLE
feat: Non-empty workspace deletion prevention

### DIFF
--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -130,4 +130,4 @@ down-scoping, config flags, the RBAC algorithm, and a code layout map.
 The SECA resource organization is hierarchical — Tenants 1—\* Workspaces 1—\* resources — and deletion is intended to cascade down this hierarchy. The building block for this is namespace ownership rather than Kubernetes owner references (none are set today):
 
 - A `Workspace`'s resources live in the workspace's dedicated namespace (see [Namespacing Strategy](#namespacing-strategy)), so deleting that namespace removes everything in the workspace at once.
-- Automatic cascade is not fully wired yet: deleting a `Workspace` CR does not yet delete its namespace (`NamespaceManagingWriterAdapter.Delete` deletes only the CR), and with no `Tenant` entity there is no tenant-level deletion to cascade from.
+- `NamespaceManagingWriterAdapter.Delete` refuses delete when the child namespace still has SECA resources (empty check over injected GVRs), then deletes the CR and the owned child namespace. With no `Tenant` entity there is no tenant-level deletion to cascade from.

--- a/framework/backend/kubernetes/adapter.go
+++ b/framework/backend/kubernetes/adapter.go
@@ -574,26 +574,79 @@ func (a *WriterAdapter[T]) Delete(ctx context.Context, m T) error {
 	return nil
 }
 
-// Delete deletes the resource and then attempts to delete the associated namespace only if it is owned by us.
+// Delete refuses the delete when the child namespace still holds SECA resources,
+// then deletes the resource CR and, if owned, the child namespace.
 func (a *NamespaceManagingWriterAdapter[T]) Delete(ctx context.Context, m T) error {
-	// The current SECA resource organization (https://spec.secapi.cloud/docs/content/Architecture/resource-organization)
-	// contains only three hierarchical levels: Tenants 1<->* Workspaces 1<->* SECA Resources.
-	//
-	// At present, there is not a Tenant entity defined, and the only entity
-	// which will really manage its namespace is the Workspace.
-	//
-	// The Workspace should be placed into the Tenant namespace, and it should
-	// not own that namespace because it will contain all the Workspaces and
-	// other elements owned by the Tenant.
-	//
-	// So, in fact, the Workspaces will create and manage namespaces for its
-	// underlying resources, and not for themselves.
-	//
-	// That's why the namespace name must always consider Tenant and Workspace
-	// names here.
+	childNS, ownerLabels := childNamespaceFor(a.childNamespace, m)
 
-	// Delete the resource which manages the namespace
-	return a.WriterAdapter.Delete(ctx, m)
+	if childNS != "" {
+		hasChildren, err := namespaceHasChildResources(ctx, a.client, childNS, a.childResourceGVRs)
+		if err != nil {
+			a.logger.ErrorContext(ctx, "failed to check child namespace emptiness",
+				"namespace", childNS, "error", err)
+			return err
+		}
+		if hasChildren {
+			return kernel.NewError(kernel.KindConflict,
+				fmt.Errorf("cannot delete %s %q: namespace %q is not empty", a.gvr.Resource, m.GetName(), childNS))
+		}
+	}
+
+	if err := a.WriterAdapter.Delete(ctx, m); err != nil {
+		return err
+	}
+
+	if childNS == "" {
+		return nil
+	}
+
+	owned, err := namespaceOwnedBy(ctx, a.clientset, childNS, ownerLabels)
+	if err != nil {
+		a.logger.ErrorContext(ctx, "failed to verify namespace ownership after resource delete",
+			"namespace", childNS, "error", err)
+		return kubeToDomainError(fmt.Errorf("failed to verify ownership of namespace %q: %w", childNS, err))
+	}
+	if !owned {
+		return nil
+	}
+
+	if err := DeleteNamespace(ctx, a.clientset, childNS); err != nil {
+		a.logger.ErrorContext(ctx, "failed to delete owned child namespace",
+			"namespace", childNS, "error", err)
+		return err
+	}
+	return nil
+}
+
+// namespaceHasChildResources reports whether any of the given GVRs has at least one
+// object in namespace. Missing CRDs (NotFound) are ignored so partial installs still work.
+// An empty gvrs list means there is nothing to check — the namespace is treated as empty.
+func namespaceHasChildResources(
+	ctx context.Context,
+	dyn dynamic.Interface,
+	namespace string,
+	gvrs []schema.GroupVersionResource,
+) (bool, error) {
+	if dyn == nil {
+		return false, kernel.NewError(kernel.KindUnavailable, fmt.Errorf("cannot list child resources: dynamic client is nil"))
+	}
+	if namespace == "" || len(gvrs) == 0 {
+		return false, nil
+	}
+
+	for _, gvr := range gvrs {
+		list, err := dyn.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{Limit: 1})
+		if err != nil {
+			if kerrs.IsNotFound(err) {
+				continue
+			}
+			return false, kubeToDomainError(fmt.Errorf("failed to list %s in namespace %q: %w", gvr.Resource, namespace, err))
+		}
+		if len(list.Items) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // Watch implements the persistence.WatcherRepo interface.
@@ -688,14 +741,16 @@ func childNamespaceLabels(tenant, workspace, network string) (string, map[string
 
 // NamespaceManagingWriterAdapter wraps a WriterAdapter and ensures the namespace computed for
 // childNamespace exists before creating resources, rolling back that namespace if it created it
-// and the resource creation subsequently fails. It uses a typed clientset for Namespace
-// operations when available.
+// and the resource creation subsequently fails. On Delete it refuses when childResourceGVRs
+// still list objects in that namespace, then deletes the CR and the owned child namespace.
+// It uses a typed clientset for Namespace operations when available.
 type NamespaceManagingWriterAdapter[T persistence.IdentifiableResource] struct {
 	*WriterAdapter[T]
-	client         dynamic.Interface
-	clientset      kubernetes.Interface
-	logger         *slog.Logger
-	childNamespace ChildNamespaceKind
+	client            dynamic.Interface
+	clientset         kubernetes.Interface
+	logger            *slog.Logger
+	childNamespace    ChildNamespaceKind
+	childResourceGVRs []schema.GroupVersionResource
 }
 
 // NamespaceManagingRepoAdapter implements the persistence.WatcherRepo interface for a specific resource type.
@@ -707,6 +762,8 @@ type NamespaceManagingRepoAdapter[T persistence.IdentifiableResource] struct {
 
 // NewNamespaceManagingWriterAdapter creates a new writer adapter that ensures the namespace
 // selected by childNamespace exists before creating resources.
+// childResourceGVRs is the closed set of SECA types that may live in the child namespace;
+// Delete uses it for the emptiness check (empty/nil means no types to check).
 func NewNamespaceManagingWriterAdapter[T persistence.IdentifiableResource](
 	dynClient dynamic.Interface,
 	clientset kubernetes.Interface,
@@ -715,14 +772,16 @@ func NewNamespaceManagingWriterAdapter[T persistence.IdentifiableResource](
 	domainToK8s DomainToK8s[T],
 	k8sToDomain K8sToDomain[T],
 	childNamespace ChildNamespaceKind,
+	childResourceGVRs []schema.GroupVersionResource,
 ) *NamespaceManagingWriterAdapter[T] {
 	base := NewWriterAdapter(dynClient, gvr, logger, domainToK8s, k8sToDomain)
 	return &NamespaceManagingWriterAdapter[T]{
-		WriterAdapter:  base,
-		client:         dynClient,
-		clientset:      clientset,
-		logger:         logger,
-		childNamespace: childNamespace,
+		WriterAdapter:     base,
+		client:            dynClient,
+		clientset:         clientset,
+		logger:            logger,
+		childNamespace:    childNamespace,
+		childResourceGVRs: childResourceGVRs,
 	}
 }
 
@@ -735,6 +794,7 @@ func NewNamespaceManagingRepoAdapter[T persistence.IdentifiableResource](
 	domainToK8s DomainToK8s[T],
 	k8sToDomain K8sToDomain[T],
 	childNamespace ChildNamespaceKind,
+	childResourceGVRs []schema.GroupVersionResource,
 ) *NamespaceManagingRepoAdapter[T] {
 	return &NamespaceManagingRepoAdapter[T]{
 		ReaderAdapter: NewReaderAdapter(
@@ -751,6 +811,7 @@ func NewNamespaceManagingRepoAdapter[T persistence.IdentifiableResource](
 			domainToK8s,
 			k8sToDomain,
 			childNamespace,
+			childResourceGVRs,
 		),
 		WatcherAdapter: NewWatcherAdapter(
 			dynClient,

--- a/framework/backend/kubernetes/adapter_test.go
+++ b/framework/backend/kubernetes/adapter_test.go
@@ -338,7 +338,7 @@ func TestNamespaceManagingWriterAdapter_Delete(t *testing.T) {
 		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(), parentListKinds(), parentObj, newChildObject(childNS, "bs-1"),
 		)
-		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+		cs := k8sfake.NewClientset(&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: childNS, Labels: ownerLabels},
 		})
 
@@ -373,7 +373,7 @@ func TestNamespaceManagingWriterAdapter_Delete(t *testing.T) {
 		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(), parentListKinds(), parentObj,
 		)
-		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+		cs := k8sfake.NewClientset(&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: childNS, Labels: ownerLabels},
 		})
 
@@ -403,7 +403,7 @@ func TestNamespaceManagingWriterAdapter_Delete(t *testing.T) {
 			runtime.NewScheme(), parentListKinds(), parentObj,
 		)
 		// Namespace exists but lacks ownership labels.
-		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+		cs := k8sfake.NewClientset(&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: childNS},
 		})
 
@@ -432,7 +432,7 @@ func TestNamespaceManagingWriterAdapter_Delete(t *testing.T) {
 		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(), parentListKinds(), parentObj, newChildObject(childNS, "bs-1"),
 		)
-		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+		cs := k8sfake.NewClientset(&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: childNS, Labels: ownerLabels},
 		})
 
@@ -501,7 +501,7 @@ func TestNamespaceManagingWriterAdapter_Delete_NetworkChildren(t *testing.T) {
 		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(), networkParentListKinds(), parentObj, newChildObject(networkChildNS, "subnet-1"),
 		)
-		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+		cs := k8sfake.NewClientset(&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: networkChildNS, Labels: ownerLabels},
 		})
 
@@ -534,7 +534,7 @@ func TestNamespaceManagingWriterAdapter_Delete_NetworkChildren(t *testing.T) {
 		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
 			runtime.NewScheme(), networkParentListKinds(), parentObj,
 		)
-		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+		cs := k8sfake.NewClientset(&corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: networkChildNS, Labels: ownerLabels},
 		})
 

--- a/framework/backend/kubernetes/adapter_test.go
+++ b/framework/backend/kubernetes/adapter_test.go
@@ -7,13 +7,18 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	kerrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/eu-sovereign-cloud/ecp/framework/backend/kubernetes/labels"
+	"github.com/eu-sovereign-cloud/ecp/framework/kernel"
 	kernelresource "github.com/eu-sovereign-cloud/ecp/framework/kernel/resource"
 )
 
@@ -236,4 +241,316 @@ func TestChildNamespaceFor_NoChildNamespace(t *testing.T) {
 
 	require.Empty(t, namespace)
 	require.Nil(t, ownerLabels)
+}
+
+// --- NamespaceManagingWriterAdapter.Delete: empty-check + owned NS cleanup ---
+
+var (
+	testParentGVR = schema.GroupVersionResource{Group: "workspace.test", Version: "v1", Resource: "workspaces"}
+	testChildGVR  = schema.GroupVersionResource{Group: "storage.test", Version: "v1", Resource: "blockstorages"}
+)
+
+func parentListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		testParentGVR: "WorkspaceList",
+		testChildGVR:  "BlockStorageList",
+	}
+}
+
+// parentDomainToK8s places the parent CR in the tenant namespace (like WorkspaceToCR).
+func parentDomainToK8s(m *testWorkspaceScopedIdentifiable) (client.Object, error) {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "workspace.test/v1",
+		"kind":       "Workspace",
+		"metadata": map[string]any{
+			"namespace": ComputeNamespace(&kernelresource.Scope{Tenant: m.tenant}),
+			"name":      m.name,
+		},
+	}}, nil
+}
+
+func parentK8sToDomain(obj client.Object) (*testWorkspaceScopedIdentifiable, error) {
+	return &testWorkspaceScopedIdentifiable{name: obj.GetName(), tenant: "t1"}, nil
+}
+
+func newChildObject(namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "storage.test/v1",
+		"kind":       "BlockStorage",
+		"metadata":   map[string]any{"namespace": namespace, "name": name},
+	}}
+}
+
+func TestNamespaceHasChildResources(t *testing.T) {
+	childNS := ComputeNamespace(&kernelresource.Scope{Tenant: "t1", Workspace: "w1"})
+	gvrs := []schema.GroupVersionResource{testChildGVR}
+
+	t.Run("empty namespace", func(t *testing.T) {
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), parentListKinds())
+		has, err := namespaceHasChildResources(context.Background(), dynFake, childNS, gvrs)
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+
+	t.Run("namespace with a child resource", func(t *testing.T) {
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), parentListKinds(), newChildObject(childNS, "bs-1"),
+		)
+		has, err := namespaceHasChildResources(context.Background(), dynFake, childNS, gvrs)
+		require.NoError(t, err)
+		require.True(t, has)
+	})
+
+	t.Run("nil gvrs means empty", func(t *testing.T) {
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), parentListKinds(), newChildObject(childNS, "bs-1"),
+		)
+		has, err := namespaceHasChildResources(context.Background(), dynFake, childNS, nil)
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+
+	t.Run("empty namespace name means empty", func(t *testing.T) {
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), parentListKinds())
+		has, err := namespaceHasChildResources(context.Background(), dynFake, "", gvrs)
+		require.NoError(t, err)
+		require.False(t, has)
+	})
+}
+
+func TestNamespaceManagingWriterAdapter_Delete(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	parent := &testWorkspaceScopedIdentifiable{name: "w1", tenant: "t1"}
+	// WorkspaceChildren uses GetName() as the workspace segment.
+	childNS := ComputeNamespace(&kernelresource.Scope{Tenant: "t1", Workspace: "w1"})
+	tenantNS := ComputeNamespace(&kernelresource.Scope{Tenant: "t1"})
+	ownerLabels := map[string]string{
+		labels.InternalTenantLabel:    "t1",
+		labels.InternalWorkspaceLabel: "w1",
+	}
+
+	t.Run("refuses delete when child namespace has SECA resources", func(t *testing.T) {
+		parentObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "workspace.test/v1",
+			"kind":       "Workspace",
+			"metadata":   map[string]any{"namespace": tenantNS, "name": "w1"},
+		}}
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), parentListKinds(), parentObj, newChildObject(childNS, "bs-1"),
+		)
+		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: childNS, Labels: ownerLabels},
+		})
+
+		writer := NewNamespaceManagingWriterAdapter[*testWorkspaceScopedIdentifiable](
+			dynFake, cs, testParentGVR, logger, parentDomainToK8s, parentK8sToDomain,
+			WorkspaceChildren, []schema.GroupVersionResource{testChildGVR},
+		)
+
+		err := writer.Delete(context.Background(), parent)
+		require.Error(t, err)
+		var domainErr *kernel.Error
+		require.ErrorAs(t, err, &domainErr)
+		require.Equal(t, kernel.KindConflict, domainErr.Kind)
+
+		// Parent CR must still exist.
+		_, getErr := dynFake.Resource(testParentGVR).Namespace(tenantNS).Get(
+			context.Background(), "w1", metav1.GetOptions{},
+		)
+		require.NoError(t, getErr)
+
+		// Child namespace must still exist.
+		_, nsErr := cs.CoreV1().Namespaces().Get(context.Background(), childNS, metav1.GetOptions{})
+		require.NoError(t, nsErr)
+	})
+
+	t.Run("deletes parent and owned empty child namespace", func(t *testing.T) {
+		parentObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "workspace.test/v1",
+			"kind":       "Workspace",
+			"metadata":   map[string]any{"namespace": tenantNS, "name": "w1"},
+		}}
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), parentListKinds(), parentObj,
+		)
+		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: childNS, Labels: ownerLabels},
+		})
+
+		writer := NewNamespaceManagingWriterAdapter[*testWorkspaceScopedIdentifiable](
+			dynFake, cs, testParentGVR, logger, parentDomainToK8s, parentK8sToDomain,
+			WorkspaceChildren, []schema.GroupVersionResource{testChildGVR},
+		)
+
+		require.NoError(t, writer.Delete(context.Background(), parent))
+
+		_, getErr := dynFake.Resource(testParentGVR).Namespace(tenantNS).Get(
+			context.Background(), "w1", metav1.GetOptions{},
+		)
+		require.True(t, kerrs.IsNotFound(getErr), "parent CR should be deleted")
+
+		_, nsErr := cs.CoreV1().Namespaces().Get(context.Background(), childNS, metav1.GetOptions{})
+		require.True(t, kerrs.IsNotFound(nsErr), "owned empty child namespace should be deleted")
+	})
+
+	t.Run("does not delete child namespace that is not owned", func(t *testing.T) {
+		parentObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "workspace.test/v1",
+			"kind":       "Workspace",
+			"metadata":   map[string]any{"namespace": tenantNS, "name": "w1"},
+		}}
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), parentListKinds(), parentObj,
+		)
+		// Namespace exists but lacks ownership labels.
+		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: childNS},
+		})
+
+		writer := NewNamespaceManagingWriterAdapter[*testWorkspaceScopedIdentifiable](
+			dynFake, cs, testParentGVR, logger, parentDomainToK8s, parentK8sToDomain,
+			WorkspaceChildren, []schema.GroupVersionResource{testChildGVR},
+		)
+
+		require.NoError(t, writer.Delete(context.Background(), parent))
+
+		_, getErr := dynFake.Resource(testParentGVR).Namespace(tenantNS).Get(
+			context.Background(), "w1", metav1.GetOptions{},
+		)
+		require.True(t, kerrs.IsNotFound(getErr))
+
+		_, nsErr := cs.CoreV1().Namespaces().Get(context.Background(), childNS, metav1.GetOptions{})
+		require.NoError(t, nsErr, "unowned namespace must not be deleted")
+	})
+
+	t.Run("NoChildNamespace skips empty check and namespace cleanup", func(t *testing.T) {
+		parentObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "workspace.test/v1",
+			"kind":       "Workspace",
+			"metadata":   map[string]any{"namespace": tenantNS, "name": "w1"},
+		}}
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), parentListKinds(), parentObj, newChildObject(childNS, "bs-1"),
+		)
+		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: childNS, Labels: ownerLabels},
+		})
+
+		writer := NewNamespaceManagingWriterAdapter[*testWorkspaceScopedIdentifiable](
+			dynFake, cs, testParentGVR, logger, parentDomainToK8s, parentK8sToDomain,
+			NoChildNamespace, []schema.GroupVersionResource{testChildGVR},
+		)
+
+		require.NoError(t, writer.Delete(context.Background(), parent))
+
+		_, getErr := dynFake.Resource(testParentGVR).Namespace(tenantNS).Get(
+			context.Background(), "w1", metav1.GetOptions{},
+		)
+		require.True(t, kerrs.IsNotFound(getErr))
+
+		_, nsErr := cs.CoreV1().Namespaces().Get(context.Background(), childNS, metav1.GetOptions{})
+		require.NoError(t, nsErr, "NoChildNamespace must not delete the child namespace")
+	})
+}
+
+// Network CR lives in the workspace namespace; NetworkChildren provisions a separate
+// per-network namespace for subnet/route-table (same shape as gateway wiring).
+var testNetworkParentGVR = schema.GroupVersionResource{Group: "network.test", Version: "v1", Resource: "networks"}
+
+func networkParentListKinds() map[schema.GroupVersionResource]string {
+	return map[schema.GroupVersionResource]string{
+		testNetworkParentGVR: "NetworkList",
+		testChildGVR:         "BlockStorageList", // stand-in for subnet/route-table
+	}
+}
+
+func networkParentDomainToK8s(m *testWorkspaceScopedIdentifiable) (client.Object, error) {
+	// Network CRs sit in the workspace namespace (tenant + workspace), not the network child NS.
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "network.test/v1",
+		"kind":       "Network",
+		"metadata": map[string]any{
+			"namespace": ComputeNamespace(&kernelresource.Scope{Tenant: m.tenant, Workspace: m.workspace}),
+			"name":      m.name,
+		},
+	}}, nil
+}
+
+func networkParentK8sToDomain(obj client.Object) (*testWorkspaceScopedIdentifiable, error) {
+	return &testWorkspaceScopedIdentifiable{name: obj.GetName(), tenant: "t1", workspace: "w1"}, nil
+}
+
+func TestNamespaceManagingWriterAdapter_Delete_NetworkChildren(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// NetworkChildren uses GetName() as the network segment and GetWorkspace() for the workspace.
+	network := &testWorkspaceScopedIdentifiable{name: "net1", tenant: "t1", workspace: "w1"}
+	workspaceNS := ComputeNamespace(&kernelresource.Scope{Tenant: "t1", Workspace: "w1"})
+	networkChildNS := ComputeNetworkNamespace(fakeNetworkScope{tenant: "t1", workspace: "w1", network: "net1"})
+	ownerLabels := map[string]string{
+		labels.InternalTenantLabel:    "t1",
+		labels.InternalWorkspaceLabel: "w1",
+		labels.InternalNetworkLabel:   "net1",
+	}
+
+	t.Run("refuses delete when network child namespace has resources", func(t *testing.T) {
+		parentObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "network.test/v1",
+			"kind":       "Network",
+			"metadata":   map[string]any{"namespace": workspaceNS, "name": "net1"},
+		}}
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), networkParentListKinds(), parentObj, newChildObject(networkChildNS, "subnet-1"),
+		)
+		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: networkChildNS, Labels: ownerLabels},
+		})
+
+		writer := NewNamespaceManagingWriterAdapter[*testWorkspaceScopedIdentifiable](
+			dynFake, cs, testNetworkParentGVR, logger, networkParentDomainToK8s, networkParentK8sToDomain,
+			NetworkChildren, []schema.GroupVersionResource{testChildGVR},
+		)
+
+		err := writer.Delete(context.Background(), network)
+		require.Error(t, err)
+		var domainErr *kernel.Error
+		require.ErrorAs(t, err, &domainErr)
+		require.Equal(t, kernel.KindConflict, domainErr.Kind)
+
+		_, getErr := dynFake.Resource(testNetworkParentGVR).Namespace(workspaceNS).Get(
+			context.Background(), "net1", metav1.GetOptions{},
+		)
+		require.NoError(t, getErr, "network CR must remain when children exist")
+
+		_, nsErr := cs.CoreV1().Namespaces().Get(context.Background(), networkChildNS, metav1.GetOptions{})
+		require.NoError(t, nsErr, "network child namespace must remain when children exist")
+	})
+
+	t.Run("deletes network and owned empty network child namespace", func(t *testing.T) {
+		parentObj := &unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "network.test/v1",
+			"kind":       "Network",
+			"metadata":   map[string]any{"namespace": workspaceNS, "name": "net1"},
+		}}
+		dynFake := fake.NewSimpleDynamicClientWithCustomListKinds(
+			runtime.NewScheme(), networkParentListKinds(), parentObj,
+		)
+		cs := k8sfake.NewSimpleClientset(&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: networkChildNS, Labels: ownerLabels},
+		})
+
+		writer := NewNamespaceManagingWriterAdapter[*testWorkspaceScopedIdentifiable](
+			dynFake, cs, testNetworkParentGVR, logger, networkParentDomainToK8s, networkParentK8sToDomain,
+			NetworkChildren, []schema.GroupVersionResource{testChildGVR},
+		)
+
+		require.NoError(t, writer.Delete(context.Background(), network))
+
+		_, getErr := dynFake.Resource(testNetworkParentGVR).Namespace(workspaceNS).Get(
+			context.Background(), "net1", metav1.GetOptions{},
+		)
+		require.True(t, kerrs.IsNotFound(getErr), "network CR should be deleted")
+
+		_, nsErr := cs.CoreV1().Namespaces().Get(context.Background(), networkChildNS, metav1.GetOptions{})
+		require.True(t, kerrs.IsNotFound(nsErr), "owned empty network child namespace should be deleted")
+	})
 }

--- a/gateway/cmd/regionalapiserver.go
+++ b/gateway/cmd/regionalapiserver.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/homedir"
@@ -231,6 +232,10 @@ func startRegional(logger *slog.Logger, addr string, kubeconfigPath string) erro
 		netk8s.NetworkToCR,
 		netk8s.NetworkFromCR,
 		k8sadapter.NetworkChildren,
+		[]schema.GroupVersionResource{
+			routetablek8s.RouteTableGVR,
+			subnetk8s.SubnetGVR,
+		},
 	)
 	netSKUReaderAdapter := k8sadapter.NewReaderAdapter[*netskudom.NetworkSKU](
 		client.Client,
@@ -420,6 +425,17 @@ func startRegional(logger *slog.Logger, addr string, kubeconfigPath string) erro
 		wsk8s.WorkspaceToCR,
 		wsk8s.WorkspaceFromCR,
 		k8sadapter.WorkspaceChildren,
+		[]schema.GroupVersionResource{
+			bsk8s.BlockStorageGVR,
+			imgk8s.ImageGVR,
+			netk8s.NetworkGVR,
+			nick8s.NICGVR,
+			publicipk8s.PublicIPGVR,
+			internetgatewayk8s.InternetGatewayGVR,
+			securitygroupk8s.SecurityGroupGVR,
+			securitygrouprulek8s.SecurityGroupRuleGVR,
+			instancek8s.InstanceGVR,
+		},
 	)
 	wsReaderAdapter := k8sadapter.NewReaderAdapter[*wsdom.Workspace](
 		client.Client,

--- a/resource/workspace/v1/backend/kubernetes/workspace_envtest_test.go
+++ b/resource/workspace/v1/backend/kubernetes/workspace_envtest_test.go
@@ -54,6 +54,7 @@ func TestWorkspaceBackend(t *testing.T) {
 		WorkspaceToCR,
 		WorkspaceFromCR,
 		k8sadapter.WorkspaceChildren,
+		nil, // no child GVRs in this suite; emptiness check is a no-op
 	)
 
 	readerRepo := k8sadapter.NewReaderAdapter[*wsdom.Workspace](

--- a/test/integration/delegator/main_test.go
+++ b/test/integration/delegator/main_test.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -169,6 +170,11 @@ func TestMain(m *testing.M) {
 		wsk8s.WorkspaceToCR,
 		wsk8s.WorkspaceFromCR,
 		k8sadapter.WorkspaceChildren,
+		[]schema.GroupVersionResource{
+			bsk8s.BlockStorageGVR,
+			netk8s.NetworkGVR,
+			instancek8s.InstanceGVR,
+		},
 	)
 
 	// Provide Workspace for BlockStorage tests

--- a/test/integration/gateway-regional/main_test.go
+++ b/test/integration/gateway-regional/main_test.go
@@ -13,6 +13,7 @@ import (
 	authhelper "github.com/eu-sovereign-cloud/ecp/test/internal/authhelper"
 
 	computev1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.compute.v1"
+	networkv1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.network.v1"
 	storagev1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.storage.v1"
 	workspacev1 "github.com/eu-sovereign-cloud/go-sdk/pkg/spec/foundation.workspace.v1"
 	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
@@ -33,6 +34,7 @@ const (
 
 var (
 	computeClient   *computev1.ClientWithResponses
+	networkClient   *networkv1.ClientWithResponses
 	storageClient   *storagev1.ClientWithResponses
 	workspaceClient *workspacev1.ClientWithResponses
 
@@ -69,6 +71,10 @@ func TestMain(m *testing.M) {
 	storageClient, err = storagev1.NewClientWithResponses(baseURL+"/providers/seca.storage", storagev1.WithRequestEditorFn(editor))
 	if err != nil {
 		log.Fatalf("Failed to create storage SDK client: %v", err)
+	}
+	networkClient, err = networkv1.NewClientWithResponses(baseURL+"/providers/seca.network", networkv1.WithRequestEditorFn(editor))
+	if err != nil {
+		log.Fatalf("Failed to create network SDK client: %v", err)
 	}
 	computeClient, err = computev1.NewClientWithResponses(baseURL+"/providers/seca.compute", computev1.WithRequestEditorFn(editor))
 	if err != nil {

--- a/test/integration/gateway-regional/network_test.go
+++ b/test/integration/gateway-regional/network_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/eu-sovereign-cloud/go-sdk/pkg/spec/schema"
+)
+
+// newNetworkBody builds the request body for creating a network.
+func newNetworkBody(cidr string) schema.Network {
+	return schema.Network{
+		Spec: schema.NetworkSpec{
+			Cidr:   schema.Cidr{Ipv4: cidr},
+			SkuRef: schema.Reference{Resource: "network-sku-1"},
+		},
+	}
+}
+
+// newRouteTableBody builds a minimal route table body used as a network child.
+func newRouteTableBody(destinationCIDR string) schema.RouteTable {
+	return schema.RouteTable{
+		Spec: schema.RouteTableSpec{
+			Routes: []schema.RouteSpec{
+				{
+					DestinationCidrBlock: destinationCIDR,
+					TargetRef:            schema.Reference{Resource: "internet-gateways/igw"},
+				},
+			},
+		},
+	}
+}
+
+// TestNetworkAPI exercises the regional gateway's network REST handler. Create,
+// read-back, and delete are verified through the gateway's HTTP responses;
+// reconciliation to Active is covered by the delegator suite, so this suite needs no
+// reconciler.
+func TestNetworkAPI(t *testing.T) {
+	t.Run("should create and retrieve a network resource via the gateway API", func(t *testing.T) {
+		//
+		// Given a unique network name
+		networkName := "test-net-create-" + uuid.New().String()[:8]
+
+		//
+		// When we create it through the gateway
+		createResp, err := networkClient.CreateOrUpdateNetworkWithResponse(
+			context.Background(), testTenant, testWorkspace, networkName, nil, newNetworkBody("10.30.0.0/16"),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
+
+		//
+		// Then it can be read back with the spec we sent
+		getResp, err := networkClient.GetNetworkWithResponse(context.Background(), testTenant, testWorkspace, networkName)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.NotNil(t, getResp.JSON200.Metadata)
+		require.Equal(t, networkName, getResp.JSON200.Metadata.Name)
+		require.Equal(t, "10.30.0.0/16", getResp.JSON200.Spec.Cidr.Ipv4)
+		require.Equal(t, "network-sku-1", getResp.JSON200.Spec.SkuRef.Resource)
+
+		//
+		// And it can be deleted
+		delResp, err := networkClient.DeleteNetworkWithResponse(context.Background(), testTenant, testWorkspace, networkName, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
+	})
+
+	t.Run("should delete a network resource via the gateway API", func(t *testing.T) {
+		//
+		// Given a network that has been created
+		networkName := "test-net-delete-" + uuid.New().String()[:8]
+		createResp, err := networkClient.CreateOrUpdateNetworkWithResponse(
+			context.Background(), testTenant, testWorkspace, networkName, nil, newNetworkBody("10.31.0.0/16"),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createResp.StatusCode())
+
+		//
+		// When we delete it, the gateway accepts the request
+		delResp, err := networkClient.DeleteNetworkWithResponse(context.Background(), testTenant, testWorkspace, networkName, nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
+	})
+
+	t.Run("should reject network deletion when a route table exists", func(t *testing.T) {
+		//
+		// Given a network that holds a route table
+		networkName := "test-net-nonempty-" + uuid.New().String()[:8]
+		rtName := "test-rt-block-delete-" + uuid.New().String()[:8]
+
+		createNet, err := networkClient.CreateOrUpdateNetworkWithResponse(
+			context.Background(), testTenant, testWorkspace, networkName, nil, newNetworkBody("10.32.0.0/16"),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createNet.StatusCode())
+
+		createRT, err := networkClient.CreateOrUpdateRouteTableWithResponse(
+			context.Background(), testTenant, testWorkspace, networkName, rtName, nil, newRouteTableBody("10.32.0.0/16"),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createRT.StatusCode())
+
+		t.Cleanup(func() {
+			_, _ = networkClient.DeleteRouteTableWithResponse(context.Background(), testTenant, testWorkspace, networkName, rtName, nil)
+			_, _ = networkClient.DeleteNetworkWithResponse(context.Background(), testTenant, testWorkspace, networkName, nil)
+		})
+
+		//
+		// When we try to delete the network while the route table still exists
+		delResp, err := networkClient.DeleteNetworkWithResponse(context.Background(), testTenant, testWorkspace, networkName, nil)
+		require.NoError(t, err)
+
+		//
+		// Then the gateway refuses with 409 Conflict
+		require.Equal(t, http.StatusConflict, delResp.StatusCode())
+		require.NotNil(t, delResp.JSON409)
+
+		//
+		// And the network is still readable
+		getResp, err := networkClient.GetNetworkWithResponse(context.Background(), testTenant, testWorkspace, networkName)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.Equal(t, networkName, getResp.JSON200.Metadata.Name)
+	})
+}

--- a/test/integration/gateway-regional/workspace_test.go
+++ b/test/integration/gateway-regional/workspace_test.go
@@ -59,4 +59,44 @@ func TestWorkspaceAPI(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusAccepted, delResp.StatusCode())
 	})
+
+	t.Run("should reject workspace deletion when a block storage exists", func(t *testing.T) {
+		//
+		// Given a workspace that holds a block storage
+		workspaceName := "test-ws-nonempty-" + uuid.New().String()[:8]
+		bsName := "test-bs-block-delete-" + uuid.New().String()[:8]
+
+		createWS, err := workspaceClient.CreateOrUpdateWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil, schema.Workspace{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createWS.StatusCode())
+
+		createBS, err := storageClient.CreateOrUpdateBlockStorageWithResponse(
+			context.Background(), testTenant, workspaceName, bsName, nil, newBlockStorageBody(1),
+		)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, createBS.StatusCode())
+
+		t.Cleanup(func() {
+			_, _ = storageClient.DeleteBlockStorageWithResponse(context.Background(), testTenant, workspaceName, bsName, nil)
+			_, _ = workspaceClient.DeleteWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil)
+		})
+
+		//
+		// When we try to delete the workspace while the block storage still exists
+		delResp, err := workspaceClient.DeleteWorkspaceWithResponse(context.Background(), testTenant, workspaceName, nil)
+		require.NoError(t, err)
+
+		//
+		// Then the gateway refuses with 409 Conflict
+		require.Equal(t, http.StatusConflict, delResp.StatusCode())
+		require.NotNil(t, delResp.JSON409)
+
+		//
+		// And the workspace is still readable
+		getResp, err := workspaceClient.GetWorkspaceWithResponse(context.Background(), testTenant, workspaceName)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, getResp.StatusCode())
+		require.NotNil(t, getResp.JSON200)
+		require.Equal(t, workspaceName, getResp.JSON200.Metadata.Name)
+	})
 }


### PR DESCRIPTION
Implements #220 
- workspace deletion is prevented if any SECA resources still exist in the workspace
- network deletion is prevented if a routing table of a subnet still exists in the network