### PR TITLE
fix: populate SKU and image identity metadata from internal labels

### DIFF
--- a/gateway/config/k8s-dev-setup/regional/storage/storage-sku.yaml
+++ b/gateway/config/k8s-dev-setup/regional/storage/storage-sku.yaml
@@ -3,7 +3,12 @@ apiVersion: storage.v1.secapi.cloud/v1
 kind: StorageSKU
 metadata:
   labels:
-    secapi.cloud/tenant-id: seca
+    # Identity is read back from these labels by StorageSKUFromCR. The provider
+    # encodes "/" as "_" because "/" is not a legal label value character.
+    # "secapi.cloud/tenant-id" is the namespace-level key and is not read here.
+    secapi.cloud/provider: seca.storage_v1
+    secapi.cloud/region: region
+    secapi.cloud/tenant: seca
   name: fast-local
   namespace: 69e09dd4c334335d2f0a4a52c9ff87b76b0f9e1b147d62a5f2b8f965 # seca
 spec:

--- a/resource/compute/v1/sku/backend/kubernetes/conversion.go
+++ b/resource/compute/v1/sku/backend/kubernetes/conversion.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,7 @@ func InstanceSKUFromCR(obj client.Object) (*skudom.InstanceSKU, error) {
 	sku.ResourceVersion = cr.GetResourceVersion()
 	sku.CreatedAt = cr.GetCreationTimestamp().Time
 	sku.UpdatedAt = cr.GetCreationTimestamp().Time
-	sku.Provider = internalLabels[k8slabels.InternalProviderLabel]
+	sku.Provider = strings.ReplaceAll(internalLabels[k8slabels.InternalProviderLabel], "_", "/")
 	sku.Region = internalLabels[k8slabels.InternalRegionLabel]
 	sku.Tenant = internalLabels[k8slabels.InternalTenantLabel]
 

--- a/resource/compute/v1/sku/backend/kubernetes/conversion_test.go
+++ b/resource/compute/v1/sku/backend/kubernetes/conversion_test.go
@@ -17,8 +17,11 @@ import (
 
 const (
 	testProvider = "seca.compute/v1"
-	testRegion   = "eu-central-1"
-	testTenant   = "tn-1"
+	// testProviderLabel is testProvider as it is stored on the CR: "/" is not a
+	// legal label value character, so it is encoded as "_".
+	testProviderLabel = "seca.compute_v1"
+	testRegion        = "eu-central-1"
+	testTenant        = "tn-1"
 )
 
 // newInstanceSKUCR builds an InstanceSKU CR with the given identity, internal labels
@@ -30,7 +33,7 @@ func newInstanceSKUCR(name, version string, vcpu, ram int, createdAt time.Time) 
 			Name:            name,
 			ResourceVersion: version,
 			Labels: map[string]string{
-				k8slabels.InternalProviderLabel: testProvider,
+				k8slabels.InternalProviderLabel: testProviderLabel,
 				k8slabels.InternalRegionLabel:   testRegion,
 				k8slabels.InternalTenantLabel:   testTenant,
 			},

--- a/resource/network/v1/network-sku/backend/kubernetes/conversion.go
+++ b/resource/network/v1/network-sku/backend/kubernetes/conversion.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,7 +41,7 @@ func NetworkSKUFromCR(obj client.Object) (*skudom.NetworkSKU, error) {
 	sku.ResourceVersion = cr.GetResourceVersion()
 	sku.CreatedAt = cr.GetCreationTimestamp().Time
 	sku.UpdatedAt = cr.GetCreationTimestamp().Time
-	sku.Provider = internalLabels[k8slabels.InternalProviderLabel]
+	sku.Provider = strings.ReplaceAll(internalLabels[k8slabels.InternalProviderLabel], "_", "/")
 	sku.Region = internalLabels[k8slabels.InternalRegionLabel]
 	sku.Tenant = internalLabels[k8slabels.InternalTenantLabel]
 

--- a/resource/network/v1/network-sku/backend/kubernetes/conversion_test.go
+++ b/resource/network/v1/network-sku/backend/kubernetes/conversion_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8slabels "github.com/eu-sovereign-cloud/ecp/framework/backend/kubernetes/labels"
 	skudom "github.com/eu-sovereign-cloud/ecp/resource/network/v1/network-sku"
 
 	. "github.com/eu-sovereign-cloud/ecp/resource/network/v1/network-sku/backend/kubernetes"
@@ -41,6 +42,28 @@ func TestNetworkSKUToCR(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 10000, sku.Spec.Bandwidth)
 		require.Equal(t, 80000, sku.Spec.Packets)
+	})
+
+	t.Run("identity_is_read_from_internal_labels", func(t *testing.T) {
+		cr := &NetworkSKU{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "seca.n1k",
+				Labels: map[string]string{
+					// The provider is stored with "/" encoded as "_", since "/"
+					// is not a legal label value character.
+					k8slabels.InternalProviderLabel: "seca.network_v1",
+					k8slabels.InternalRegionLabel:   "eu-central-1",
+					k8slabels.InternalTenantLabel:   "tn-1",
+				},
+			},
+			Spec: NetworkSkuSpec{Bandwidth: 1000, Packets: 10000},
+		}
+
+		sku, err := NetworkSKUFromCR(cr)
+		require.NoError(t, err)
+		require.Equal(t, "seca.network/v1", sku.Provider)
+		require.Equal(t, "eu-central-1", sku.Region)
+		require.Equal(t, "tn-1", sku.Tenant)
 	})
 
 	t.Run("nil_errors", func(t *testing.T) {

--- a/resource/storage/v1/storage-sku/backend/kubernetes/conversion.go
+++ b/resource/storage/v1/storage-sku/backend/kubernetes/conversion.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -41,7 +42,7 @@ func StorageSKUFromCR(obj client.Object) (*skudom.StorageSKU, error) {
 	sku.ResourceVersion = cr.GetResourceVersion()
 	sku.CreatedAt = cr.GetCreationTimestamp().Time
 	sku.UpdatedAt = cr.GetCreationTimestamp().Time
-	sku.Provider = internalLabels[k8slabels.InternalProviderLabel]
+	sku.Provider = strings.ReplaceAll(internalLabels[k8slabels.InternalProviderLabel], "_", "/")
 	sku.Region = internalLabels[k8slabels.InternalRegionLabel]
 	sku.Tenant = internalLabels[k8slabels.InternalTenantLabel]
 

--- a/resource/storage/v1/storage-sku/backend/kubernetes/conversion_test.go
+++ b/resource/storage/v1/storage-sku/backend/kubernetes/conversion_test.go
@@ -17,8 +17,11 @@ import (
 
 const (
 	testProvider = "seca.storage/v1"
-	testRegion   = "eu-central-1"
-	testTenant   = "tn-1"
+	// testProviderLabel is testProvider as it is stored on the CR: "/" is not a
+	// legal label value character, so it is encoded as "_".
+	testProviderLabel = "seca.storage_v1"
+	testRegion        = "eu-central-1"
+	testTenant        = "tn-1"
 )
 
 // newStorageSKUCR builds a StorageSKU CR with the given identity, internal labels
@@ -30,7 +33,7 @@ func newStorageSKUCR(name, version string, iops, minVolumeSize int, skuType stri
 			Name:            name,
 			ResourceVersion: version,
 			Labels: map[string]string{
-				k8slabels.InternalProviderLabel: testProvider,
+				k8slabels.InternalProviderLabel: testProviderLabel,
 				k8slabels.InternalRegionLabel:   testRegion,
 				k8slabels.InternalTenantLabel:   testTenant,
 			},

--- a/test/internal/deploy/test-data/compute-skus.yaml
+++ b/test/internal/deploy/test-data/compute-skus.yaml
@@ -4,6 +4,12 @@ metadata:
   name: compute-sku-1
   # hex(sha3-224("test-tenant")) — the ECP namespace for tenant "test-tenant"; see namespace.yaml.
   namespace: f7ec6f666803cd9d9814d4c055217581afbff53f3c35fd6c5e6b444d
+  labels:
+    # Identity is read back from these labels by InstanceSKUFromCR. The provider
+    # encodes "/" as "_" because "/" is not a legal label value character.
+    secapi.cloud/provider: seca.compute_v1
+    secapi.cloud/region: itbg-bergamo
+    secapi.cloud/tenant: test-tenant
 spec:
   vCPU: 4
   ram: 8

--- a/test/internal/deploy/test-data/images.yaml
+++ b/test/internal/deploy/test-data/images.yaml
@@ -7,6 +7,11 @@ metadata:
   labels:
     base: ubuntu
     version: "24.04"
+    # Identity is read back from these labels by ImageFromCR. The provider
+    # encodes "/" as "_" because "/" is not a legal label value character.
+    secapi.cloud/provider: seca.storage_v1
+    secapi.cloud/region: itbg-bergamo
+    secapi.cloud/tenant: test-tenant
 spec:
   cpuArchitecture: amd64
   boot: UEFI

--- a/test/internal/deploy/test-data/network-skus.yaml
+++ b/test/internal/deploy/test-data/network-skus.yaml
@@ -4,6 +4,12 @@ metadata:
   name: network-sku-1
   # hex(sha3-224("test-tenant")) — the ECP namespace for tenant "test-tenant"; see namespace.yaml.
   namespace: f7ec6f666803cd9d9814d4c055217581afbff53f3c35fd6c5e6b444d
+  labels:
+    # Identity is read back from these labels by NetworkSKUFromCR. The provider
+    # encodes "/" as "_" because "/" is not a legal label value character.
+    secapi.cloud/provider: seca.network_v1
+    secapi.cloud/region: itbg-bergamo
+    secapi.cloud/tenant: test-tenant
 spec:
   bandwidth: 1000
   packets: 1000000

--- a/test/internal/deploy/test-data/storagesku.yaml
+++ b/test/internal/deploy/test-data/storagesku.yaml
@@ -4,6 +4,12 @@ metadata:
   name: sku-1
   # hex(sha3-224("test-tenant")) — the ECP namespace for tenant "test-tenant"; see namespace.yaml.
   namespace: f7ec6f666803cd9d9814d4c055217581afbff53f3c35fd6c5e6b444d
+  labels:
+    # Identity is read back from these labels by StorageSKUFromCR. The provider
+    # encodes "/" as "_" because "/" is not a legal label value character.
+    secapi.cloud/provider: seca.storage_v1
+    secapi.cloud/region: itbg-bergamo
+    secapi.cloud/tenant: test-tenant
 spec:
   iops: 5000
   minVolumeSize: 1
@@ -14,6 +20,10 @@ kind: StorageSKU
 metadata:
   name: sku-2
   namespace: f7ec6f666803cd9d9814d4c055217581afbff53f3c35fd6c5e6b444d
+  labels:
+    secapi.cloud/provider: seca.storage_v1
+    secapi.cloud/region: itbg-bergamo
+    secapi.cloud/tenant: test-tenant
 spec:
   iops: 10000
   minVolumeSize: 10


### PR DESCRIPTION
## Problem

`metadata.provider`, `metadata.region` and `metadata.tenant` came back empty on every SKU (network, instance, storage) and on images, which also produced a malformed ref with a double slash: `/tenants//skus/sku1`.

The `*FromCR` converters read identity from the `secapi.cloud/provider|region|tenant` labels. Writable resources set those labels in their `ToCR`, but SKUs and images are read-only and seeded from YAML — and none of the seed manifests carried them. The dev-setup manifest set `secapi.cloud/tenant-id`, which is the namespace-level key, not the one read here.

The three SKU converters also read the provider label raw, while every other resource decodes `_` back to `/` (`/` is not a legal label value character).

## Fix

- Add `secapi.cloud/provider`, `secapi.cloud/region` and `secapi.cloud/tenant` to the SKU and image seed manifests.
- Decode `_` → `/` on the provider label in the network, instance and storage SKU converters, matching the existing convention.
- Cover identity conversion in the network-sku test, which had no such case.