### PR TITLE
test: expose the KIND gateways on fixed NodePorts

### DIFF
--- a/test/internal/deploy/gateway-global/values.yaml
+++ b/test/internal/deploy/gateway-global/values.yaml
@@ -7,3 +7,8 @@
 
 gatewayRegional:
   enabled: false
+
+gatewayGlobal:
+  service:
+    type: NodePort
+    nodePort: 30080

--- a/test/internal/deploy/gateway-regional/values.yaml
+++ b/test/internal/deploy/gateway-regional/values.yaml
@@ -11,3 +11,6 @@ gatewayGlobal:
 gatewayRegional:
   # Must match a region in test-data/regions.yaml.
   region: itbg-bergamo
+  service:
+    type: NodePort
+    nodePort: 30081

--- a/test/internal/kind-config/regional-cluster.yaml
+++ b/test/internal/kind-config/regional-cluster.yaml
@@ -17,3 +17,6 @@ nodes:
       - containerPort: 30080
         hostPort: 30080
         protocol: TCP
+      - containerPort: 30081
+        hostPort: 30081
+        protocol: TCP


### PR DESCRIPTION
## What

The gateway services in the KIND test deployments defaulted to `ClusterIP`, so nothing outside the cluster could reach them.

- `test/internal/deploy/gateway-global/values.yaml` — global gateway service becomes `NodePort` on `30080`
- `test/internal/deploy/gateway-regional/values.yaml` — regional gateway service becomes `NodePort` on `30081`
- `test/internal/kind-config/regional-cluster.yaml` — maps container port `30081` to host `30081` on the control-plane node

Both ports are already supported by the chart (`*.service.type` / `*.service.nodePort` in `charts/ecp`), so this is values/KIND config only — no template changes.

## Why

So the host can reach the regional gateway the same way it already reaches the global one, which is what tests and the global gateway's provider URLs need when the regional gateway lives in a separate KIND cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)