### PR TITLE
feat(gateway): verify JWT issuer/audience and gate requests on the token's tenant membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ resource/             # Data vocabulary + per-resource slices (vertical axis)
     ├── frontend/rest/#   REST↔domain converters + HTTP handlers (per-group, shared handler)
     └── backend/kubernetes/ # CR types, adapters, controller, plugin interface + handler
 gateway/              # Global and regional REST API server binary
-├── internal/authn/   #   DummyAuthenticator (bearer-token dev/test auth)
+├── internal/authn/   #   Dummy (dev/test) and JWT (signature-verifying) authenticators
 ├── internal/authz/   #   seca/ — SECA RBAC Checker + CachedChecker
 └── internal/auth/    #   Build, ProviderMWs, StartChecker — opt-in wiring
 csp/

--- a/charts/ecp/README.md
+++ b/charts/ecp/README.md
@@ -117,6 +117,12 @@ cluster in that mode. Two authentication plugins exist (`auth.plugin`):
   too). The plugin applies to **both** gateways — the binary registers the
   same auth flags on the global and the regional server.
 
+  Set `auth.jwt.issuer` and `auth.jwt.audience` to your IdP's issuer URL and
+  this API's identifier. Each is enforced only when set — and enforcing one
+  also makes that claim mandatory — so a token minted for another service, or
+  by another issuer sharing the key, is rejected rather than accepted on its
+  signature alone.
+
 Every auth value becomes a **command-line flag** on the gateway container: the
 images are the bare binary, and it reads only `APP_ENV` from the environment.
 Adding a knob to this chart therefore means adding it to `ecp.authArgs` in
@@ -139,6 +145,7 @@ See [values.yaml](values.yaml) for the full commented list. The notable ones:
 | `auth.plugin` | `dummy` | Authenticator for both gateways: `dummy` or `jwt` |
 | `auth.jwt.signingMethod` | `ES256` | Pinned JWT `alg` when `auth.plugin=jwt` |
 | `auth.jwt.key` | `""` | PEM public key / raw HS\* secret (required for `jwt` unless `auth.jwt.existingSecret`) |
+| `auth.jwt.issuer` / `auth.jwt.audience` | `""` | Expected `iss` / `aud`; each is enforced (and required in the token) only when set |
 | `auth.authz.impl` | `cached` | `cached` (informer) or `direct` (per-request) checker |
 | `auth.dummyUsers.users` | `{}` | username → password map (required when `auth.plugin=dummy`) |
 | `*.image.repository` | `ghcr.io/eu-sovereign-cloud/ecp/...` | Override only to mirror the images into your own registry |

--- a/charts/ecp/templates/_helpers.tpl
+++ b/charts/ecp/templates/_helpers.tpl
@@ -117,6 +117,12 @@ defaults to seca.region.
 {{- if eq .Values.auth.plugin "jwt" }}
 - --jwt-signing-method={{ .Values.auth.jwt.signingMethod }}
 - --jwt-secret=/etc/ecp/jwt/jwt.pub
+{{- with .Values.auth.jwt.issuer }}
+- --jwt-issuer={{ . }}
+{{- end }}
+{{- with .Values.auth.jwt.audience }}
+- --jwt-audience={{ . }}
+{{- end }}
 {{- else }}
 - --dummy-auth-users=/etc/ecp/auth/users.json
 {{- end }}

--- a/charts/ecp/values.yaml
+++ b/charts/ecp/values.yaml
@@ -32,6 +32,13 @@ auth:
     # Name of a pre-existing Secret with a "jwt.pub" key. Takes precedence
     # over key.
     existingSecret: ""
+    # Expected "iss" claim. Empty accepts any issuer; set it to your IdP's
+    # issuer URL so a token minted elsewhere is rejected even when it is
+    # signed with a key this gateway trusts.
+    issuer: ""
+    # Expected "aud" claim. Empty accepts any audience; set it to this API's
+    # identifier so a token issued for another service is rejected.
+    audience: ""
   authz:
     # RBAC authorization (only effective when auth.enabled).
     enabled: true

--- a/doc/ARCHITECTURE.md
+++ b/doc/ARCHITECTURE.md
@@ -127,7 +127,8 @@ chain. When enabled (`--auth-enabled`), every request must carry a valid
 `Authorization: Bearer <token>` header and the decoded identity must be
 authorised by the RBAC policy before the request reaches the handler. A caller's
 roles are resolved from `RoleAssignment`/`Role` in the tenant namespace — never
-from the token, which carries only the subject and an optional down-scope.
+from the token, which carries only the subject, the issuer-asserted tenant
+membership and an optional down-scope (the last two cap the request, never grant).
 
 ```
 HTTP request
@@ -156,7 +157,8 @@ All framework-layer types (`Authenticator`, `Checker`, `ClaimExtractor`,
 resource-agnostic. Concrete implementations (`DummyAuthenticator`, SECA RBAC
 `Checker`, `CachedChecker`) live in `gateway/` and may import `resource/`.
 
-See [doc/AUTH.md](AUTH.md) for the full reference — bearer-token format, token
+See [doc/AUTH.md](AUTH.md) for the full reference — bearer-token formats (dummy and
+signed JWT), issuer/audience verification, the tenant-membership gate, token
 down-scoping, config flags, the RBAC algorithm, and a code layout map.
 
 ## Cascaded Deletion

--- a/doc/AUTH-SPEC-REVIEW.md
+++ b/doc/AUTH-SPEC-REVIEW.md
@@ -5,14 +5,18 @@ see [AUTH.md](AUTH.md)) against the SECA specification: what the bearer token mu
 carry, where authentication and authorization decisions belong, and where the current
 implementation diverges from the spec.
 
-> **Status — implemented on `feat/gateway-auth-middleware`.** The final model:
-> the bearer token carries the **subject** (`subs`) plus an optional **`scope`**
-> down-scope (`tenants`/`regions`/`workspaces`) only. **Roles are resolved entirely from
+> **Status — implemented** (`feat/gateway-auth-middleware`, [#316](https://github.com/eu-sovereign-cloud/ecp/pull/316); the
+> signature-verifying authenticator followed in [#334](https://github.com/eu-sovereign-cloud/ecp/pull/334) and the §6
+> checklist was finished after it). The final model:
+> the bearer token carries the **subject** (`sub`), the issuer-asserted **`tenants`**
+> membership gate and an optional **`scope`** down-scope
+> (`tenants`/`regions`/`workspaces`) — nothing else. **Roles are resolved entirely from
 > `RoleAssignment`/`Role` in the tenant namespace and are never read from the token.**
 > The `scope` object can only *narrow* what a token may exercise (see [AUTH.md](AUTH.md)
 > § Token down-scoping). Authentication verifies token authenticity against a **fixed,
-> operator-configured endpoint** — any endpoint named inside the token is ignored; the
-> shipped Dummy authenticator validates username/password. **Region is a tenant-less
+> operator-configured endpoint** — any endpoint named inside the token is ignored, as are
+> its `iss`/`aud` unless the operator configured what to expect; the shipped Dummy
+> authenticator validates username/password. **Region is a tenant-less
 > catalog resource by design** — upstream confirmed the current path shape is correct,
 > so no spec-side correction is coming. Tenant-scoped RBAC cannot govern it: the gateway
 > serves `seca.region` authn-only via the configurable `--authz-skip-providers` list
@@ -86,8 +90,9 @@ The rule that decides what belongs in the token (**grant vs cap**):
 |---|---|---|
 | `sub` | **Required** | The only claim the spec's usage guide requires: *"The JWT must contain a `sub` claim that identifies you"*. Matched against `RoleAssignment.spec.subs` ("subject IDs (from JWT)"). |
 | Signature, `iss`, `aud`, `exp` | **Required** | Standard JWT validation; spec also lists a *revocation check* (needs short TTLs or an introspection endpoint — offline verification alone cannot satisfy it). |
-| `scope.tenants` | **Optional (cap)** | Part of the down-scope; a non-empty list caps which tenants the token may act in. Caller-asserted (narrows only). A *signed* IdP-asserted tenant membership gate remains future work (see §5). |
+| `scope.tenants` | **Optional (cap)** | Part of the down-scope; a non-empty list caps which tenants the token may act in. Caller-asserted (narrows only); the issuer-asserted gate is the `tenants` claim below, and both are enforced. |
 | `scope.regions` / `scope.workspaces` | **Optional (cap)** | The other down-scope dimensions, matched against the request's region/workspace. Absent = no restriction; skipped when the request has no value for that dimension. |
+| `tenants` | **Optional (gate)** | Issuer-asserted tenant membership → `Identity.MemberTenants`. Non-empty ⇒ the request's tenant must be listed. Unlike `scope.tenants` the caller cannot omit it, so it is what makes a `subs: ["*"]` grant mean "every member of this tenant" (see §5). |
 | `roles` | **Removed — never read** | Entitlement assertion — resolved solely from the RoleAssignment store. Any `roles` field in the token is ignored. See §4. |
 | `permissions` | **Must NOT appear** | Worse than roles: inlines policy itself, bypassing even the Role indirection — the IdP would own *what a role means*, not just who has it. |
 
@@ -106,8 +111,8 @@ Supporting spec language:
 
 **Authentication (→ 401)** — validates the credential, produces identity:
 
-- Verify signature / issuer / audience / expiry; revocation strategy TBD.
-- Output: `Identity{Subject, Tenant(s)}`. Nothing else is needed from the token.
+- Verify signature / issuer / audience / expiry; revocation via short token TTLs (§6).
+- Output: `Identity{Subject, MemberTenants, TokenScope}`. Nothing else is needed from the token.
 - Tenant-mismatch placement depends on the IdP topology:
   - **Per-tenant issuer** (e.g. Keycloak realm per tenant): wrong-tenant token fails issuer
     validation → **401**, check lives in authn.
@@ -125,9 +130,11 @@ Supporting spec language:
 **Technical failure (→ 500)** — RBAC store unreachable, cache read failure. Never
 disguised as a denial; already implemented correctly in the current middleware.
 
-Current implementation status: chain, error categories, and RBAC evaluation exist and
-match this placement. Missing: real JWT verification (dummy authenticator only), tenant
-claim in `Identity` + membership gate, and the roles-claim divergence below.
+Current implementation status: all of it. The chain, error categories and RBAC evaluation
+match this placement; the `jwt` plugin verifies signature, `alg`, `exp` and the configured
+`iss`/`aud`; the tenant claim reaches `Identity.MemberTenants` and is gated in the
+evaluator (**403**, the single-shared-issuer placement — this deployment has one JWKS-less
+configured key, not an issuer per tenant); and the roles-claim divergence below is gone.
 
 ---
 
@@ -176,12 +183,13 @@ still shrink its own blast radius without the IdP ever needing to know a caller'
 
 ## 5. Other sharp edges
 
-- **`subs: ["*"]` wildcard**: schema says *"all users of the tenant scopes"*, but the
-  implementation grants it to **every authenticated principal**. The token's `scope`
-  down-scope is *caller-asserted*, so it does **not** constrain the wildcard — a wildcard
-  assignment genuinely grants everyone. A real membership gate would have to come from a
-  signed, IdP-asserted tenant claim in the future authenticator; until then `*` is a
-  footgun on a shared issuer. (The e2e fixtures used to need a wildcard assignment so
+- **`subs: ["*"]` wildcard (resolved)**: schema says *"all users of the tenant scopes"*,
+  but on its own the implementation grants it to **every authenticated principal** — the
+  token's `scope` down-scope is *caller-asserted*, so it does not constrain the wildcard.
+  The `tenants` claim closes this: an issuer that stamps membership on every token it
+  mints turns `*` into "every member of this tenant", because the gate runs before the
+  assignment loop. An issuer that stamps nothing leaves the old footgun, so `*` still
+  wants care on a shared issuer. (The e2e fixtures used to need a wildcard assignment so
   every caller could list regions; serving `seca.region` authn-only removed that need,
   and the `ra-wildcard` fixture with it.)
 - **Tenant-less routes**: an empty tenant makes `ComputeNamespace` return `""`, which
@@ -214,12 +222,26 @@ Done on `feat/gateway-auth-middleware`:
 - [x] Serve the tenant-less region catalog authn-only — authorization layer skipped per
       provider via the configurable `--authz-skip-providers` (default `seca.region`).
 
-Remaining for the real (signature-verifying) authenticator:
+Done for the real (signature-verifying) `jwt` authenticator:
 
-- [ ] Verify signature via the operator-configured verification endpoint / JWKS, plus
-      `iss`, `aud`, `exp`; ignore any endpoint named inside the token.
-- [ ] Decide the subject claim (`sub` vs `email`) — it must match the identifier
-      convention used in `RoleAssignment.spec.subs` platform-wide.
-- [ ] Optionally add a *signed*, IdP-asserted tenant-membership gate (distinct from the
-      caller-asserted `scope.tenants` cap, which cannot constrain a `subs: ["*"]` grant).
-- [ ] Pick a revocation strategy: short-lived tokens + refresh, or an introspection call.
+- [x] Verify the signature against the operator-configured key (`--jwt-secret`) with the
+      `alg` pinned to `--jwt-signing-method`, plus mandatory `exp` and the configured
+      `iss`/`aud` (`--jwt-issuer`, `--jwt-audience` — each enforced *and* required in the
+      token when set). Nothing named inside the token selects how it is verified.
+- [x] Subject claim: **`sub`**, platform-wide — it is what `RoleAssignment.spec.subs`
+      lists, so an issuer identifying users by email puts the email in `sub`.
+- [x] Signed, IdP-asserted tenant-membership gate: the `tenants` claim →
+      `Identity.MemberTenants`, enforced in `Evaluate` before any assignment is
+      considered, so it caps `subs: ["*"]` where the caller-asserted `scope.tenants`
+      cannot. Both caps apply, so the effective set is their intersection.
+- [x] Revocation strategy: **short-lived tokens + refresh at the issuer**, with `exp`
+      mandatory so a token cannot opt out. Per-request introspection was rejected — a
+      network round-trip on the hot path and a hard dependency on IdP availability. See
+      [AUTH.md](AUTH.md) § Token lifetime and revocation.
+
+Deliberately not implemented (no current deployment needs it):
+
+- **JWKS / OIDC discovery.** The key is a mounted file, rotated by rotating the file. An
+  issuer that rotates keys on its own schedule would want discovery plus a key cache.
+- **A configurable name for the tenant-membership claim** (`tid`, `org_id`, …). Map it to
+  `tenants` on the issuer instead.

--- a/doc/AUTH.md
+++ b/doc/AUTH.md
@@ -64,12 +64,14 @@ after it apply to both.
 ### Dummy authenticator (`--auth-plugin=dummy`)
 
 The token is a **Base64-encoded JSON payload**. Only `username` and `password` are
-mandatory; the optional `scope` object down-scopes the caller (see below):
+mandatory; the optional `scope` object down-scopes the caller and the optional `tenants`
+list stands in for the membership a real issuer would stamp (see below):
 
 ```json
 {
   "username": "alice",
   "password": "s3cr3t",
+  "tenants": ["my-tenant"],
   "scope": { "tenants": ["my-tenant"], "regions": ["itbg-bergamo"] }
 }
 ```
@@ -102,14 +104,20 @@ The payload uses registered claims plus the same optional `scope` object:
 {
   "sub": "alice",
   "exp": 1893456000,
+  "iss": "https://idp.example",
+  "aud": "seca-api",
+  "tenants": ["my-tenant"],
   "scope": { "tenants": ["my-tenant"], "regions": ["itbg-bergamo"] }
 }
 ```
 
 | Claim | Required | Meaning |
 |-------|----------|---------|
-| `sub` | yes | Becomes `Identity.Subject` — the same role of the dummy token's `username`. A token without it is rejected. |
+| `sub` | yes | Becomes `Identity.Subject` — the same role of the dummy token's `username`. A token without it is rejected. The subject claim is `sub`, platform-wide: it is what `RoleAssignment.Spec.Subs` lists, so an issuer that identifies users by email must put the email in `sub`. |
 | `exp` | yes | Expiry. Enforced with `jwt.WithExpirationRequired`, so a token that never expires is rejected rather than honoured forever. |
+| `iss` | when `--jwt-issuer` is set | Must equal the configured issuer. Setting the flag also makes the claim mandatory. |
+| `aud` | when `--jwt-audience` is set | Must contain the configured audience. Setting the flag also makes the claim mandatory. |
+| `tenants` | no | Issuer-asserted tenant membership — see [Tenant membership](#tenant-membership-the-tenants-claim). |
 | `scope` | no | Token down-scope, identical to the dummy token's (see below). |
 
 A token is accepted only when its signature verifies **and** its `alg` header
@@ -120,6 +128,27 @@ and have it verify. Any algorithm `golang-jwt` supports may be configured.
 
 As with the dummy plugin, **roles are never carried by the token** — a `roles`
 claim is ignored, and entitlements come only from RoleAssignments.
+
+#### Issuer and audience (`--jwt-issuer`, `--jwt-audience`)
+
+A valid signature only says *this key signed it*. It does not say who minted the
+token or which service it was minted for, and the same key routinely signs tokens
+for other audiences. Both checks are therefore configuration, not claims to be
+trusted from the token itself:
+
+- `--jwt-issuer` — the expected `iss`. A token from another issuer sharing the key
+  is rejected.
+- `--jwt-audience` — the expected `aud` (matched against the claim's list). A token
+  minted for a different service and replayed here is rejected.
+
+Each is enforced only when set, and setting it also makes that claim **mandatory** —
+a token that simply omits `iss`/`aud` is rejected exactly like one carrying the wrong
+value, so an issuer cannot opt out of the check by dropping the claim. Leave them
+empty only when a single issuer mints tokens for this gateway alone.
+
+Nothing named *inside* the token selects how it is verified: the key, the signing
+method, the issuer and the audience all come from flags. A token that names its own
+verification endpoint is verifying itself.
 
 #### Verification key (`--jwt-secret`)
 
@@ -160,6 +189,51 @@ every request at runtime.
 > openssl ec -in jwt-key.pem -pubout -out jwt-key.pub                # public key for --jwt-secret
 > ```
 
+#### Token lifetime and revocation
+
+The gateway verifies tokens **offline** — one signature check against a key it already
+holds, no call to the issuer — so a token stays valid until it expires no matter what
+happens to the account behind it. The strategy that closes the gap is therefore
+**short-lived tokens plus refresh at the issuer**, and `exp` is mandatory
+(`jwt.WithExpirationRequired`) so a token cannot opt out of it: revocation latency is
+whatever TTL your issuer mints, and a revoked user stops being served once their current
+token expires. Removing their `RoleAssignment` is immediate by comparison — RBAC is read
+per request — so it is the faster lever when a caller must lose access *now*.
+
+The alternative, an introspection call to the issuer per request, buys instant revocation
+at the price of a network round-trip on the hot path (and a hard dependency on the IdP's
+availability). It is deliberately not implemented; short TTLs cover the common case.
+
+### Tenant membership (the `tenants` claim)
+
+The optional `tenants` claim is the tenant membership the **issuer** asserts about the
+subject — static onboarding data the CSP's IdP genuinely owns (see
+[AUTH-SPEC-REVIEW.md](AUTH-SPEC-REVIEW.md) §1). It reaches the authorization layer as
+`Identity.MemberTenants` and gates every request: when the list is non-empty, the
+request's tenant must appear in it or the request is denied with **403**.
+
+It looks like `scope.tenants` and matches identically, but the two differ in who asserts
+them, which is the whole point:
+
+| | `tenants` | `scope.tenants` |
+|---|---|---|
+| Asserted by | the issuer, on every token it mints | the caller, when requesting the token |
+| Can be omitted by the caller | no | yes |
+| Caps a `subs: ["*"]` assignment | yes | no — the caller just omits it |
+
+Both are enforced, so the effective cap is their intersection: an issuer-stamped
+membership of `["a","b"]` with a self-requested scope of `["b"]` reaches only `b`.
+
+The claim is a **gate, not a grant**: being a member of a tenant authorizes nothing on
+its own — a RoleAssignment in that tenant's namespace still has to grant the operation.
+An absent claim imposes no gate, which is what keeps pre-existing issuers (and every
+fixture token) working; deploy an issuer that always stamps it if you rely on the gate.
+Like the down-scope, it is skipped on a request that carries no tenant at all — the only
+such path today is the region catalog, which is served authn-only anyway.
+
+> The claim name is fixed (`tenants`). An IdP that names it otherwise (`tid`, `org_id`, …)
+> needs a claim mapping on the issuer side.
+
 ### Token down-scoping
 
 The optional `scope` object caps what the token may exercise, per SECA scope
@@ -196,6 +270,8 @@ In code the `scope` object unmarshals into the shared `resource.TokenScope` type
 | `--dummy-auth-users <file>` | `""` | Path to a JSON file mapping `username→password`. Required when `--auth-plugin=dummy`. |
 | `--jwt-signing-method` | `ES256` | Expected JWT `alg`; tokens signed with anything else are rejected. Any `golang-jwt` method is accepted. Required when `--auth-plugin=jwt`. |
 | `--jwt-secret <file>` | `""` | Path to the verification key file: the raw HMAC secret for `HS*`, a PEM public key otherwise. Required when `--auth-plugin=jwt`. |
+| `--jwt-issuer` | `""` | Expected `iss`. Enforced (and required in the token) only when set. |
+| `--jwt-audience` | `""` | Expected `aud`. Enforced (and required in the token) only when set. |
 | `--authz-enabled` | `true` | Install the RBAC authorization middleware. Requires `--auth-enabled`. Set to `false` for authn-only mode (every authenticated caller is let through without a RBAC check). |
 | `--authz-skip-providers` | `seca.region` | Comma-separated provider IDs whose routes skip the authorization middleware (authn-only). Neither RBAC nor token down-scoping applies to these providers. |
 | `--authz-cache` | `false` | Use the informer-backed `CachedChecker` instead of the per-request `Checker`. |
@@ -270,7 +346,9 @@ openssl ec -in /tmp/jwt-key.pem -pubout -out /tmp/jwt-key.pub
     --auth-enabled \
     --auth-plugin jwt \
     --jwt-signing-method ES256 \
-    --jwt-secret /tmp/jwt-key.pub
+    --jwt-secret /tmp/jwt-key.pub \
+    --jwt-issuer https://idp.example \
+    --jwt-audience seca-api
 
 # mint a token with your issuer (or the e2e helper, authhelper.SignJWT) and send it as-is
 curl -H "Authorization: Bearer $JWT" http://localhost:8080/providers/seca.region/v1/regions
@@ -287,7 +365,8 @@ all `Role` and `RoleAssignment` resources in the claim's tenant namespace.
 
 ```
 authorized =
-    tokenScopeCovers(claim.TokenScope, claim.Tenant, claim.Region, claim.Workspace)
+    tokenScopeCovers(claim.MemberTenants, claim.Tenant)
+  ∧ tokenScopeCovers(claim.TokenScope, claim.Tenant, claim.Region, claim.Workspace)
   ∧ ∃ ra ∈ RoleAssignments:
         scopeCovers(ra.Spec.Scopes, claim.Tenant, claim.Region, claim.Workspace)
       ∧ subsGrant(ra.Spec.Subs, claim.Subject)
@@ -300,8 +379,10 @@ authorized =
 ```
 
 Roles are taken solely from the matched `RoleAssignment`; the token never carries
-roles. `claim.TokenScope` is the optional token cap applied first — a non-empty
-dimension must cover the request, or the whole claim is denied.
+roles. `claim.MemberTenants` (issuer-asserted membership) and `claim.TokenScope`
+(the caller's down-scope) are the optional caps applied first — a non-empty one must
+cover the request, or the whole claim is denied. Being applied before the assignment
+loop is what lets the membership gate constrain a `subs: ["*"]` grant.
 
 ### Subject matching
 
@@ -310,7 +391,7 @@ The SECA spec makes it **mandatory** (`minItems: 1`). Matching rules:
 
 | Value | Meaning |
 |-------|---------|
-| `"*"` | Wildcard — covers any authenticated caller. |
+| `"*"` | Wildcard — covers any authenticated caller, narrowed to the token's `tenants` membership when the issuer stamps one. |
 | `"user1@example.com"` | Exact match against `claim.Subject`. |
 | _(empty list)_ | Grants **nobody** — fail-closed (not a wildcard). |
 

--- a/doc/AUTH.md
+++ b/doc/AUTH.md
@@ -26,7 +26,7 @@ HTTP request
 ┌─────────────────────────────────────────────┐
 │  Authorization middleware                   │
 │  builds AuthorizationClaim from request     │
-│  merges Subject + TokenScope into claim     │
+│  merges identity (subject + caps) into it   │
 │  calls Checker.Authorize(ctx, claim)        │
 └─────────┬───────────────────────────────────┘
           │ DecisionAllowed → next handler
@@ -191,18 +191,13 @@ every request at runtime.
 
 #### Token lifetime and revocation
 
-The gateway verifies tokens **offline** — one signature check against a key it already
-holds, no call to the issuer — so a token stays valid until it expires no matter what
-happens to the account behind it. The strategy that closes the gap is therefore
-**short-lived tokens plus refresh at the issuer**, and `exp` is mandatory
-(`jwt.WithExpirationRequired`) so a token cannot opt out of it: revocation latency is
-whatever TTL your issuer mints, and a revoked user stops being served once their current
-token expires. Removing their `RoleAssignment` is immediate by comparison — RBAC is read
-per request — so it is the faster lever when a caller must lose access *now*.
-
-The alternative, an introspection call to the issuer per request, buys instant revocation
-at the price of a network round-trip on the hot path (and a hard dependency on the IdP's
-availability). It is deliberately not implemented; short TTLs cover the common case.
+Verification is **offline** — one signature check against a key the gateway already holds
+— so a token stays valid until it expires whatever happens to the account behind it. Use
+**short-lived tokens plus refresh at the issuer**: revocation latency is whatever TTL your
+issuer mints, and `exp` is mandatory (`jwt.WithExpirationRequired`) so a token cannot opt
+out. Removing the caller's `RoleAssignment` is immediate by comparison — RBAC is read per
+request. Per-request introspection is deliberately not implemented
+([AUTH-SPEC-REVIEW.md](AUTH-SPEC-REVIEW.md) §6).
 
 ### Tenant membership (the `tenants` claim)
 

--- a/framework/frontend/middleware/authorization.go
+++ b/framework/frontend/middleware/authorization.go
@@ -20,8 +20,8 @@ import (
 // The middleware:
 //  1. Retrieves the [authnport.Identity] injected by [NewAuthentication].
 //  2. Builds an [authzport.AuthorizationClaim] by calling extract(r) and merging
-//     the identity's Subject and TokenScope into the claim. A claim-extraction error
-//     is treated as a technical fault and yields HTTP 500.
+//     the identity's Subject, TokenScope and MemberTenants into the claim. A
+//     claim-extraction error is treated as a technical fault and yields HTTP 500.
 //  3. Calls checker.Authorize and branches on the returned [authzport.Decision]:
 //     [authzport.DecisionAllowed] → calls next handler (HTTP 2xx).
 //     [authzport.DecisionDenied]  → writes RFC 7807 HTTP 403 Forbidden.
@@ -31,9 +31,10 @@ import (
 //
 // NewAuthorization MUST be used after NewAuthentication in the middleware chain
 // so that the Identity is already present in the context. The middleware copies
-// the identity's Subject and TokenScope (the token down-scoping cap) into the claim
-// before invoking the checker. Roles are not taken from the identity — they are resolved
-// by the checker from the RBAC store.
+// the identity's Subject, TokenScope (the token down-scoping cap) and MemberTenants
+// (the issuer-asserted tenant membership) into the claim before invoking the checker.
+// Roles are not taken from the identity — they are resolved by the checker from the
+// RBAC store.
 func NewAuthorization(
 	checker authzport.Checker,
 	extract authzport.ClaimExtractor,
@@ -59,6 +60,7 @@ func NewAuthorization(
 			}
 			claim.Subject = identity.Subject
 			claim.TokenScope = identity.TokenScope
+			claim.MemberTenants = identity.MemberTenants
 
 			decision, decErr := checker.Authorize(r.Context(), claim)
 			switch decision {

--- a/framework/frontend/middleware/authorization_test.go
+++ b/framework/frontend/middleware/authorization_test.go
@@ -120,6 +120,7 @@ func TestNewAuthorization_TokenScopeFromIdentity(t *testing.T) {
 			Regions:    []string{"r1"},
 			Workspaces: []string{"w1"},
 		},
+		MemberTenants: []string{"t1", "t2"},
 	}
 
 	var gotClaim authzport.AuthorizationClaim
@@ -144,6 +145,9 @@ func TestNewAuthorization_TokenScopeFromIdentity(t *testing.T) {
 	}
 	if gotClaim.Subject != "alice" {
 		t.Errorf("subject = %q, want %q", gotClaim.Subject, "alice")
+	}
+	if !reflect.DeepEqual(gotClaim.MemberTenants, []string{"t1", "t2"}) {
+		t.Errorf("member tenants = %v, want [t1 t2]", gotClaim.MemberTenants)
 	}
 }
 

--- a/framework/kernel/port/authn/authn.go
+++ b/framework/kernel/port/authn/authn.go
@@ -27,13 +27,9 @@ type Identity struct {
 	TokenScope resource.TokenScope
 	// MemberTenants is the tenant membership the issuer asserts about the subject (the
 	// token's "tenants" claim). It is a gate, not a grant: when non-empty, the request's
-	// tenant must be listed or authorization denies the request.
-	//
-	// It differs from TokenScope.Tenants in who asserts it. The token scope is the cap the
-	// *caller* asked for and may simply omit, so it cannot constrain a RoleAssignment with
-	// subs: ["*"]; membership is stamped by the issuer on every token it mints, so a
-	// wildcard assignment reaches only subjects the issuer places in that tenant. Both are
-	// enforced, so the effective set is their intersection.
+	// tenant must be listed or authorization denies the request. Unlike TokenScope the
+	// caller cannot omit it, so it also caps a subs: ["*"] assignment — see doc/AUTH.md
+	// § Tenant membership.
 	MemberTenants []string
 }
 

--- a/framework/kernel/port/authn/authn.go
+++ b/framework/kernel/port/authn/authn.go
@@ -25,6 +25,16 @@ type Identity struct {
 	// request is denied. An empty TokenScope imposes no restriction. Down-scoping can only
 	// narrow the permissions granted by RBAC; it never grants anything.
 	TokenScope resource.TokenScope
+	// MemberTenants is the tenant membership the issuer asserts about the subject (the
+	// token's "tenants" claim). It is a gate, not a grant: when non-empty, the request's
+	// tenant must be listed or authorization denies the request.
+	//
+	// It differs from TokenScope.Tenants in who asserts it. The token scope is the cap the
+	// *caller* asked for and may simply omit, so it cannot constrain a RoleAssignment with
+	// subs: ["*"]; membership is stamped by the issuer on every token it mints, so a
+	// wildcard assignment reaches only subjects the issuer places in that tenant. Both are
+	// enforced, so the effective set is their intersection.
+	MemberTenants []string
 }
 
 // Authenticator validates a raw bearer token and returns the caller's Identity.

--- a/framework/kernel/port/authz/authz.go
+++ b/framework/kernel/port/authz/authz.go
@@ -45,6 +45,11 @@ type AuthorizationClaim struct {
 	// identity. When a dimension is non-empty the request's tenant/region/workspace must
 	// be listed; it can only narrow the permissions granted by RBAC, never grant them.
 	TokenScope resource.TokenScope
+	// MemberTenants is the issuer-asserted tenant membership copied from
+	// [authnport.Identity.MemberTenants]. When non-empty, Tenant must be listed or the
+	// claim is denied — a gate applied before any RoleAssignment is considered, so it
+	// also constrains assignments granted to subs: ["*"].
+	MemberTenants []string
 
 	// Provider identifies the SECA provider being accessed (e.g. "seca.compute").
 	Provider string

--- a/gateway/internal/auth/config.go
+++ b/gateway/internal/auth/config.go
@@ -41,6 +41,12 @@ type Flags struct {
 	JwtSigningMethod string
 	// JwtSecretFile is the path to a file holding the verification key for JWTs when AuthPlugin is "jwt". Required when AuthPlugin is "jwt". For HS* the file content is the raw HMAC secret; for all other methods it is a PEM-encoded PKIX public key.
 	JwtSecretFile string
+	// JwtIssuer is the expected "iss" claim. Empty accepts any issuer; when set, a token
+	// with a different or missing issuer is rejected.
+	JwtIssuer string
+	// JwtAudience is the expected "aud" claim. Empty accepts any audience; when set, a
+	// token whose audience does not include it (or omits the claim) is rejected.
+	JwtAudience string
 	// DummyUsersFile is the path to a JSON file containing username→password pairs.
 	// Required when Enabled is true. Example file content: {"alice":"s3cr3t","bob":"p@ss"}
 	DummyUsersFile string
@@ -70,6 +76,8 @@ func RegisterFlags(cmd *cobra.Command, f *Flags) {
 			"(required when --auth-enabled is set)")
 	cmd.Flags().StringVar(&f.JwtSigningMethod, "jwt-signing-method", "ES256", "Expected JWT signing method when --auth-plugin is 'jwt' (required when --auth-plugin is 'jwt')")
 	cmd.Flags().StringVar(&f.JwtSecretFile, "jwt-secret", "", "Path to a file containing the JWT verification key: the raw HMAC secret for HS*, a PEM public key otherwise (required when --auth-plugin is 'jwt')")
+	cmd.Flags().StringVar(&f.JwtIssuer, "jwt-issuer", "", "Expected JWT 'iss' claim; when set, tokens from another issuer (or without the claim) are rejected (empty accepts any issuer)")
+	cmd.Flags().StringVar(&f.JwtAudience, "jwt-audience", "", "Expected JWT 'aud' claim; when set, tokens for another audience (or without the claim) are rejected (empty accepts any audience)")
 	cmd.Flags().BoolVar(&f.AuthzCache, "authz-cache", false,
 		"Use the informer-backed CachedChecker instead of the per-request RBAC checker "+
 			"(requires --auth-enabled; reduces API-server load on hot paths)")
@@ -242,7 +250,7 @@ func buildAuthenticator(flags *Flags) (authnport.Authenticator, error) {
 		if err != nil {
 			return nil, fmt.Errorf("parse JWT key from %q: %w", flags.JwtSecretFile, err)
 		}
-		return gatewayauthn.NewJWTAuthenticator(key, flags.JwtSigningMethod), nil
+		return gatewayauthn.NewJWTAuthenticator(key, flags.JwtSigningMethod, flags.JwtIssuer, flags.JwtAudience), nil
 	}
 	return nil, fmt.Errorf("unknown auth plugin %q", flags.AuthPlugin)
 }

--- a/gateway/internal/authn/dummy.go
+++ b/gateway/internal/authn/dummy.go
@@ -17,7 +17,9 @@ import (
 // since the SDK client encodes it verbatim).
 //
 // Only username and password are mandatory. An optional "scope" object down-scopes the
-// caller's permissions and unmarshals directly into [resource.TokenScope]. Roles are NOT
+// caller's permissions and unmarshals directly into [resource.TokenScope], and an optional
+// "tenants" list stands in for the tenant membership a real issuer would stamp (both are
+// self-asserted here, which is exactly why this authenticator is dev-only). Roles are NOT
 // read from the token: they are resolved entirely from the RoleAssignment/Role resources in
 // the caller's tenant namespace. Any other field (including a client-supplied verification
 // endpoint) is ignored.
@@ -25,6 +27,7 @@ type tokenPayload struct {
 	Username string               `json:"username"`
 	Password string               `json:"password"`
 	Scope    *resource.TokenScope `json:"scope,omitempty"`
+	Tenants  []string             `json:"tenants,omitempty"`
 }
 
 // DummyAuthenticator validates bearer tokens using a static user→password map.
@@ -80,7 +83,8 @@ func (d *DummyAuthenticator) Authenticate(_ context.Context, token string) (*aut
 	}
 
 	return &authnport.Identity{
-		Subject:    payload.Username,
-		TokenScope: scope,
+		Subject:       payload.Username,
+		TokenScope:    scope,
+		MemberTenants: payload.Tenants,
 	}, nil
 }

--- a/gateway/internal/authn/dummy_test.go
+++ b/gateway/internal/authn/dummy_test.go
@@ -33,8 +33,16 @@ func TestDummyAuthenticator(t *testing.T) {
 		token       string
 		wantSubject string
 		wantScope   resource.TokenScope
+		wantTenants []string
 		wantErr     bool
 	}{
+		{
+			// The "tenants" list stands in for the membership a real issuer stamps.
+			name:        "tenants claim becomes the identity's membership",
+			token:       base64.StdEncoding.EncodeToString([]byte(`{"username":"alice","password":"s3cr3t","tenants":["t1","t2"]}`)),
+			wantSubject: "alice",
+			wantTenants: []string{"t1", "t2"},
+		},
 		{
 			name:        "valid credentials without scope",
 			token:       makeToken("alice", "s3cr3t", nil),
@@ -107,6 +115,9 @@ func TestDummyAuthenticator(t *testing.T) {
 			}
 			if id.Subject != tc.wantSubject {
 				t.Errorf("subject = %q, want %q", id.Subject, tc.wantSubject)
+			}
+			if !reflect.DeepEqual(id.MemberTenants, tc.wantTenants) {
+				t.Errorf("member tenants = %v, want %v", id.MemberTenants, tc.wantTenants)
 			}
 			if !reflect.DeepEqual(id.TokenScope, tc.wantScope) {
 				t.Errorf("token scope = %+v, want %+v", id.TokenScope, tc.wantScope)

--- a/gateway/internal/authn/jwtstd.go
+++ b/gateway/internal/authn/jwtstd.go
@@ -37,34 +37,56 @@ func ParseVerifyKey(method string, data []byte) (any, error) {
 // The key type must match the signing method: []byte for HS*,
 // *ecdsa.PublicKey for ES*, *rsa.PublicKey for RS*/PS*, ed25519.PublicKey
 // for EdDSA — see [ParseVerifyKey].
+//
+// The verification key, the accepted signing method and the expected issuer and
+// audience all come from the operator's configuration; nothing the token itself names
+// is trusted to select them.
 type JwtAuthenticator struct {
-	secret        any
-	signingMethod string
+	secret     any
+	parserOpts []jwt.ParserOption
 }
 
 // NewJWTAuthenticator creates a JwtAuthenticator.
-func NewJWTAuthenticator(secret any, signingMethod string) *JwtAuthenticator {
+//
+// issuer and audience are the expected "iss" and "aud" claim values. Each is enforced
+// only when non-empty, and enforcement also makes the claim mandatory: a token that
+// omits a configured claim is rejected. Leave them empty to accept any issuer/audience
+// (the pre-existing behaviour) — appropriate only when a single issuer mints tokens for
+// this gateway alone.
+func NewJWTAuthenticator(secret any, signingMethod, issuer, audience string) *JwtAuthenticator {
+	opts := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{signingMethod}),
+		jwt.WithExpirationRequired(),
+	}
+	if issuer != "" {
+		opts = append(opts, jwt.WithIssuer(issuer))
+	}
+	if audience != "" {
+		opts = append(opts, jwt.WithAudience(audience))
+	}
 	return &JwtAuthenticator{
-		secret:        secret,
-		signingMethod: signingMethod,
+		secret:     secret,
+		parserOpts: opts,
 	}
 }
 
 // jwtClaims is the expected JWT payload. Embedding RegisteredClaims provides
-// exp/sub validation; the optional "scope" object unmarshals directly into
-// [resource.TokenScope] and down-scopes the caller's permissions.
+// exp/sub/iss/aud validation; the optional "scope" object unmarshals directly into
+// [resource.TokenScope] and down-scopes the caller's permissions, while the optional
+// "tenants" claim carries the issuer-asserted tenant membership.
 type jwtClaims struct {
 	jwt.RegisteredClaims
-	Scope *resource.TokenScope `json:"scope,omitempty"`
+	Scope   *resource.TokenScope `json:"scope,omitempty"`
+	Tenants []string             `json:"tenants,omitempty"`
 }
 
-// Authenticate implements authnport.Authenticator, verifies the JWT token, and returns an Identity carrying the subject and any optional down-scoping asserted by the token.
-// Returns kernel.ErrUnauthorized when the token is malformed or credentials are invalid.
+// Authenticate implements authnport.Authenticator, verifies the JWT token, and returns an Identity carrying the subject, the issuer-asserted tenant membership and any optional down-scoping asserted by the token.
+// Returns kernel.ErrUnauthorized when the token is malformed, expired, signed by an unexpected key or method, or carries the wrong issuer or audience.
 func (j *JwtAuthenticator) Authenticate(_ context.Context, tokenString string) (*authnport.Identity, error) {
 	claims := &jwtClaims{}
 	_, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (any, error) {
 		return j.secret, nil
-	}, jwt.WithValidMethods([]string{j.signingMethod}), jwt.WithExpirationRequired())
+	}, j.parserOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("%w: token is not valid JWT: %w", kernel.ErrUnauthorized, err)
 	}
@@ -78,7 +100,8 @@ func (j *JwtAuthenticator) Authenticate(_ context.Context, tokenString string) (
 		scope = *claims.Scope
 	}
 	return &authnport.Identity{
-		Subject:    claims.Subject,
-		TokenScope: scope,
+		Subject:       claims.Subject,
+		TokenScope:    scope,
+		MemberTenants: claims.Tenants,
 	}, nil
 }

--- a/gateway/internal/authn/jwtstd_test.go
+++ b/gateway/internal/authn/jwtstd_test.go
@@ -98,6 +98,7 @@ func TestJWTAuthenticator(t *testing.T) {
 		signingMethod jwt.SigningMethod
 		wantSubject   string
 		wantScope     resource.TokenScope
+		wantTenants   []string
 		wantErr       bool
 	}{
 		{
@@ -152,6 +153,16 @@ func TestJWTAuthenticator(t *testing.T) {
 			wantErr:       true,
 		},
 		{
+			// The "tenants" claim reaches Identity.MemberTenants verbatim, where the
+			// authorization layer turns it into a gate on the request's tenant. Every
+			// other case leaves it unset, i.e. no gate.
+			name:          "tenants claim becomes the identity's membership",
+			token:         makeToken(keyES, jwt.SigningMethodES256, "alice", nil, jwt.MapClaims{"tenants": []string{"t1", "t2"}}),
+			signingMethod: jwt.SigningMethodES256,
+			wantSubject:   "alice",
+			wantTenants:   []string{"t1", "t2"},
+		},
+		{
 			// iss/aud are not enforced by these authenticators (both configured
 			// empty), so a token carrying them is accepted unchanged.
 			name:          "unconfigured issuer and audience are not enforced",
@@ -195,6 +206,9 @@ func TestJWTAuthenticator(t *testing.T) {
 			}
 			if !reflect.DeepEqual(id.TokenScope, tc.wantScope) {
 				t.Errorf("token scope = %+v, want %+v", id.TokenScope, tc.wantScope)
+			}
+			if !reflect.DeepEqual(id.MemberTenants, tc.wantTenants) {
+				t.Errorf("member tenants = %v, want %v", id.MemberTenants, tc.wantTenants)
 			}
 		})
 	}
@@ -280,45 +294,5 @@ func TestJWTAuthenticatorIssuerAudience(t *testing.T) {
 				t.Errorf("subject = %q, want %q", id.Subject, "alice")
 			}
 		})
-	}
-}
-
-// TestJWTAuthenticatorTenantsClaim covers the issuer-asserted tenant membership: the
-// "tenants" claim reaches Identity.MemberTenants verbatim, where the authorization
-// layer turns it into a gate on the request's tenant.
-func TestJWTAuthenticatorTenantsClaim(t *testing.T) {
-	t.Parallel()
-
-	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatalf("failed to generate key: %v", err)
-	}
-	a := NewJWTAuthenticator(&key.PublicKey, jwt.SigningMethodES256.Alg(), "", "")
-
-	sign := func(extra jwt.MapClaims) string {
-		claims := jwt.MapClaims{"sub": "alice", "exp": time.Now().Add(time.Hour).Unix()}
-		maps.Copy(claims, extra)
-		s, err := jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(key)
-		if err != nil {
-			t.Fatalf("failed to sign token: %v", err)
-		}
-		return s
-	}
-
-	id, err := a.Authenticate(context.Background(), sign(jwt.MapClaims{"tenants": []string{"t1", "t2"}}))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !reflect.DeepEqual(id.MemberTenants, []string{"t1", "t2"}) {
-		t.Errorf("member tenants = %v, want [t1 t2]", id.MemberTenants)
-	}
-
-	// Absent claim leaves membership unset, i.e. no gate.
-	id, err = a.Authenticate(context.Background(), sign(nil))
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if id.MemberTenants != nil {
-		t.Errorf("member tenants = %v, want nil", id.MemberTenants)
 	}
 }

--- a/gateway/internal/authn/jwtstd_test.go
+++ b/gateway/internal/authn/jwtstd_test.go
@@ -65,9 +65,9 @@ func TestJWTAuthenticator(t *testing.T) {
 		t.Fatalf("failed to generate RSA key: %v", err)
 	}
 
-	aES := NewJWTAuthenticator(&keyES.PublicKey, jwt.SigningMethodES256.Alg())
-	aHS := NewJWTAuthenticator(keyHS, jwt.SigningMethodHS256.Alg())
-	aRS := NewJWTAuthenticator(&keyRS.PublicKey, jwt.SigningMethodRS512.Alg())
+	aES := NewJWTAuthenticator(&keyES.PublicKey, jwt.SigningMethodES256.Alg(), "", "")
+	aHS := NewJWTAuthenticator(keyHS, jwt.SigningMethodHS256.Alg(), "", "")
+	aRS := NewJWTAuthenticator(&keyRS.PublicKey, jwt.SigningMethodRS512.Alg(), "", "")
 
 	// Helper to build a signed token from a payload. additionalClaims may
 	// override the defaults (e.g. "exp").
@@ -151,6 +151,14 @@ func TestJWTAuthenticator(t *testing.T) {
 			signingMethod: jwt.SigningMethodES256,
 			wantErr:       true,
 		},
+		{
+			// iss/aud are not enforced by these authenticators (both configured
+			// empty), so a token carrying them is accepted unchanged.
+			name:          "unconfigured issuer and audience are not enforced",
+			token:         makeToken(keyES, jwt.SigningMethodES256, "alice", nil, jwt.MapClaims{"iss": "https://other", "aud": "other-api"}),
+			signingMethod: jwt.SigningMethodES256,
+			wantSubject:   "alice",
+		},
 	}
 
 	for _, tc := range tests {
@@ -189,5 +197,128 @@ func TestJWTAuthenticator(t *testing.T) {
 				t.Errorf("token scope = %+v, want %+v", id.TokenScope, tc.wantScope)
 			}
 		})
+	}
+}
+
+// TestJWTAuthenticatorIssuerAudience covers the operator-configured iss/aud checks:
+// each is enforced only when configured, and configuring it also makes the claim
+// mandatory — a token signed with the right key but minted for another service (or by
+// another issuer sharing the key) must not be accepted on its signature alone.
+func TestJWTAuthenticatorIssuerAudience(t *testing.T) {
+	t.Parallel()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	const issuer, audience = "https://idp.example", "seca-api"
+
+	sign := func(extra jwt.MapClaims) string {
+		claims := jwt.MapClaims{"sub": "alice", "exp": time.Now().Add(time.Hour).Unix()}
+		maps.Copy(claims, extra)
+		s, err := jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(key)
+		if err != nil {
+			t.Fatalf("failed to sign token: %v", err)
+		}
+		return s
+	}
+
+	a := NewJWTAuthenticator(&key.PublicKey, jwt.SigningMethodES256.Alg(), issuer, audience)
+
+	tests := []struct {
+		name    string
+		token   string
+		wantErr bool
+	}{
+		{
+			name:  "matching issuer and audience",
+			token: sign(jwt.MapClaims{"iss": issuer, "aud": audience}),
+		},
+		{
+			name:  "audience list containing the expected value",
+			token: sign(jwt.MapClaims{"iss": issuer, "aud": []string{"other-api", audience}}),
+		},
+		{
+			name:    "wrong issuer",
+			token:   sign(jwt.MapClaims{"iss": "https://evil.example", "aud": audience}),
+			wantErr: true,
+		},
+		{
+			name:    "missing issuer",
+			token:   sign(jwt.MapClaims{"aud": audience}),
+			wantErr: true,
+		},
+		{
+			name:    "wrong audience",
+			token:   sign(jwt.MapClaims{"iss": issuer, "aud": "other-api"}),
+			wantErr: true,
+		},
+		{
+			name:    "missing audience",
+			token:   sign(jwt.MapClaims{"iss": issuer}),
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := a.Authenticate(context.Background(), tc.token)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !isUnauthorized(err) {
+					t.Errorf("expected ErrUnauthorized, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id.Subject != "alice" {
+				t.Errorf("subject = %q, want %q", id.Subject, "alice")
+			}
+		})
+	}
+}
+
+// TestJWTAuthenticatorTenantsClaim covers the issuer-asserted tenant membership: the
+// "tenants" claim reaches Identity.MemberTenants verbatim, where the authorization
+// layer turns it into a gate on the request's tenant.
+func TestJWTAuthenticatorTenantsClaim(t *testing.T) {
+	t.Parallel()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	a := NewJWTAuthenticator(&key.PublicKey, jwt.SigningMethodES256.Alg(), "", "")
+
+	sign := func(extra jwt.MapClaims) string {
+		claims := jwt.MapClaims{"sub": "alice", "exp": time.Now().Add(time.Hour).Unix()}
+		maps.Copy(claims, extra)
+		s, err := jwt.NewWithClaims(jwt.SigningMethodES256, claims).SignedString(key)
+		if err != nil {
+			t.Fatalf("failed to sign token: %v", err)
+		}
+		return s
+	}
+
+	id, err := a.Authenticate(context.Background(), sign(jwt.MapClaims{"tenants": []string{"t1", "t2"}}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(id.MemberTenants, []string{"t1", "t2"}) {
+		t.Errorf("member tenants = %v, want [t1 t2]", id.MemberTenants)
+	}
+
+	// Absent claim leaves membership unset, i.e. no gate.
+	id, err = a.Authenticate(context.Background(), sign(nil))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id.MemberTenants != nil {
+		t.Errorf("member tenants = %v, want nil", id.MemberTenants)
 	}
 }

--- a/gateway/internal/authz/seca/evaluator.go
+++ b/gateway/internal/authz/seca/evaluator.go
@@ -26,7 +26,8 @@ import (
 // Authorization algorithm:
 //
 //	authorized =
-//	    tokenScopeCovers(claim.TokenScope, tenant, region, workspace)
+//	    tokenScopeCovers(claim.MemberTenants, tenant)
+//	  ∧ tokenScopeCovers(claim.TokenScope, tenant, region, workspace)
 //	  ∧ ∃ ra ∈ assignments:
 //	        scopeCovers(ra.Scopes, tenant, region, workspace)
 //	      ∧ subsGrant(ra.Subs, claim.Subject)
@@ -42,14 +43,17 @@ import (
 // RoleAssignment.Subs restrict the grant to named subjects; "*" covers all subjects.
 // An empty Subs grants nobody (fail-closed; unlike scope slices, empty ≠ wildcard).
 //
-// claim.TokenScope is an optional token cap applied first: a non-empty dimension must cover
-// the request or the whole claim is denied. It can only narrow access, never grant it.
+// claim.MemberTenants (issuer-asserted membership) and claim.TokenScope (the caller's
+// optional down-scope) are caps applied first: a non-empty one must cover the request or
+// the whole claim is denied. Both can only narrow access, never grant it — and because
+// they run before the assignment loop, they also constrain a subs: ["*"] wildcard grant.
 func Evaluate(
 	claim authzport.AuthorizationClaim,
 	rolesByName map[string]*roledom.Role,
 	assignments []*radom.RoleAssignment,
 ) bool {
-	if !tokenScopeCovers(claim.TokenScope.Tenants, claim.Tenant) ||
+	if !tokenScopeCovers(claim.MemberTenants, claim.Tenant) ||
+		!tokenScopeCovers(claim.TokenScope.Tenants, claim.Tenant) ||
 		!tokenScopeCovers(claim.TokenScope.Regions, claim.Region) ||
 		!tokenScopeCovers(claim.TokenScope.Workspaces, claim.Workspace) {
 		return false
@@ -79,8 +83,9 @@ func Evaluate(
 	return false
 }
 
-// tokenScopeCovers reports whether an optional token-scope cap permits the request's
-// value for one dimension (tenant, region, or workspace).
+// tokenScopeCovers reports whether an optional token cap — a token-scope dimension
+// (tenant, region, or workspace) or the issuer-asserted tenant membership — permits the
+// request's value for that dimension.
 //
 // A cap denies only when it is non-empty AND the request's value is present but not listed.
 // An empty cap imposes no restriction. An empty request value means the dimension does not

--- a/gateway/internal/authz/seca/evaluator_test.go
+++ b/gateway/internal/authz/seca/evaluator_test.go
@@ -317,6 +317,40 @@ func TestEvaluate(t *testing.T) {
 			},
 			want: false, // admin grants everything, but the token cap excludes t1
 		},
+
+		// ── Issuer-asserted tenant membership (claim.MemberTenants) ───────────
+		{
+			name:        "membership covers request tenant",
+			claim:       with(baseClaim, func(c *authzport.AuthorizationClaim) { c.MemberTenants = []string{"t1", "t9"} }),
+			assignments: []*radom.RoleAssignment{assign([]string{"viewer"}, allScope)},
+			want:        true,
+		},
+		{
+			name:        "membership excludes request tenant → denied",
+			claim:       with(baseClaim, func(c *authzport.AuthorizationClaim) { c.MemberTenants = []string{"t9"} }),
+			assignments: []*radom.RoleAssignment{assign([]string{"viewer"}, allScope)},
+			want:        false,
+		},
+		{
+			name: "membership gates a subs:[*] wildcard grant the token scope cannot",
+			claim: with(baseClaim, func(c *authzport.AuthorizationClaim) {
+				c.Subject = "outsider"
+				c.MemberTenants = []string{"t9"}
+			}),
+			// assign() builds Subs:["*"], so without the membership gate every
+			// authenticated caller would be granted admin here.
+			assignments: []*radom.RoleAssignment{assign([]string{"admin"}, allScope)},
+			want:        false,
+		},
+		{
+			name: "membership and token scope are both enforced (intersection)",
+			claim: with(baseClaim, func(c *authzport.AuthorizationClaim) {
+				c.MemberTenants = []string{"t1", "t2"}
+				c.TokenScope.Tenants = []string{"t2"}
+			}),
+			assignments: []*radom.RoleAssignment{assign([]string{"viewer"}, allScope)},
+			want:        false, // member of t1, but the token narrowed itself to t2
+		},
 	}
 
 	for _, tc := range tests {

--- a/test/README.md
+++ b/test/README.md
@@ -346,7 +346,7 @@ The region catalog (`seca.region`) is served **authn-only**: `--authz-skip-provi
 | `MemberToken(user, password, tenants)` / `MemberEditor(…)` | Same, but carrying the issuer-asserted `tenants` membership instead of a down-scope. Backs the membership-gate cases in both suites; under either plugin the gate denies (403) a tenant the list omits. |
 | `JWTAuth()` | Whether the stack runs the jwt plugin; plugin-specific tests skip on it. |
 | `JWTKey()` | The fixture ES256 private key. Pass a freshly generated key instead to forge a token the gateway must reject. |
-| `SignJWT(key, subject, scope, exp)` | Sign a token for a subject, with an optional down-scope and an explicit expiry (pass a past time for an expired token). Always stamps the deployed `iss`/`aud`; the suite signs its own claim sets when it needs a token without them. |
+| `SignJWT(key, subject, scope, tenants, exp)` | Sign a token for a subject, with an optional down-scope, an optional `tenants` membership and an explicit expiry (pass a past time for an expired token). Always stamps the deployed `iss`/`aud`; the suite signs its own claim set when it needs a token carrying different ones. |
 | `JWTIssuer` / `JWTAudience` | The `iss`/`aud` the gateways are deployed to require — the same values as `auth.jwt.issuer`/`audience` above. |
 
 The key pair is a committed fixture: the private half is a constant in `authhelper`, the public half is `auth.jwt.key` in `internal/deploy/gateway-values.yaml`. The chart renders it into a Secret, mounts it at `/etc/ecp/jwt/jwt.pub` and passes that path as `--jwt-secret`. It is a Secret rather than a ConfigMap because the same value serves `signingMethod: HS*`, where the file is the shared HMAC secret that mints tokens — see [Verification key](../doc/AUTH.md#verification-key---jwt-secret). To rotate it, regenerate both halves and update both places:
@@ -368,7 +368,7 @@ make kind-integration-gateway-global    # dummy tokens (the default)
 make kind-test-all AUTH_PLUGIN=jwt      # the same suites, signed JWTs
 ```
 
-`TestJWTAuthn` (`e2e/jwt_test.go`) is the JWT-specific suite: valid/expired/unsigned-by-us tokens, algorithm-confusion attempts, wrong/missing `iss`/`aud`, dummy tokens rejected by the JWT gateway, and the `sub`/`tenants`/`scope` claims driving RBAC. It runs only under `AUTH_PLUGIN=jwt` and is the only test that covers the `--jwt-secret` file → `ParseVerifyKey` → authenticator wiring and the `--jwt-issuer`/`--jwt-audience` flags reaching the parser, since the unit tests build the authenticator from an already-parsed key.
+`TestJWTAuthn` (`e2e/jwt_test.go`) is the JWT-specific suite: valid/expired/unsigned-by-us tokens, algorithm-confusion attempts, a token from another issuer, dummy tokens rejected by the JWT gateway, and the `sub`/`tenants`/`scope` claims driving RBAC. It runs only under `AUTH_PLUGIN=jwt` and is the only test that covers the `--jwt-secret` file → `ParseVerifyKey` → authenticator wiring and the `--jwt-issuer`/`--jwt-audience` flags reaching the parser, since the unit tests build the authenticator from an already-parsed key — the full wrong/missing `iss`/`aud` matrix lives there (`gateway/internal/authn`).
 
 To skip auth assertions (e.g. against an auth-disabled gateway):
 

--- a/test/README.md
+++ b/test/README.md
@@ -298,6 +298,8 @@ Set in [`internal/deploy/gateway-values.yaml`](internal/deploy/gateway-values.ya
 | `auth.plugin` | `dummy` | `--auth-plugin` | Authenticator to run: `dummy` or `jwt`. Overridden per deployment from `AUTH_PLUGIN` and read by the suites, so it is a single setting for the whole stack. |
 | `auth.jwt.signingMethod` | `ES256` | `--jwt-signing-method` | Expected JWT `alg` when the plugin is `jwt`. Must match what the suite signs with (`authhelper.JWTSigningMethod`). |
 | `auth.jwt.key` | committed fixture | `--jwt-secret` | Verification key, rendered into a Secret and mounted at `/etc/ecp/jwt/jwt.pub`. |
+| `auth.jwt.issuer` | `https://issuer.e2e.ecp.local` | `--jwt-issuer` | Expected `iss`. Mirrored by `authhelper.JWTIssuer`, so every minted token carries it and a token from elsewhere is a 401. |
+| `auth.jwt.audience` | `ecp-e2e` | `--jwt-audience` | Expected `aud`. Mirrored by `authhelper.JWTAudience`. Setting either also makes that claim mandatory in the token. |
 | `auth.authz.enabled` | `true` | `--authz-enabled` | Set to `false` for authn-only (identity checked, no RBAC). Requires `auth.enabled`. |
 | `auth.authz.impl` | `cached` | `--authz-cache` | `cached` uses the informer-backed checker (zero K8s round-trips on hot path); `direct` uses the per-request reader (2 K8s List calls per request). |
 | `auth.authz.skipProviders` | `seca.region` | `--authz-skip-providers` | Comma-separated provider IDs served authn-only (no RBAC check, no token down-scoping). The region catalog is tenant-less by spec. |
@@ -317,6 +319,8 @@ Set in [`internal/deploy/gateway-values.yaml`](internal/deploy/gateway-values.ya
 The files in `internal/deploy/test-data/` define the RBAC state used by the auth tests. Roles are **not** carried by the token — each subject's roles come entirely from the RoleAssignment named below (the token carries only the subject and an optional down-scope). The table maps the token subject to the RoleAssignment that covers them and the net access they should receive.
 
 The subject is the dummy token's `username` or the JWT's `sub` claim; both plugins feed the same `Identity.Subject`, so **every row applies unchanged to either plugin** — the password column is simply unused for JWTs, which are trusted by signature instead.
+
+No fixture token carries a `tenants` membership, so the issuer-asserted gate is inert for every row below; the membership cases mint their own tokens with `authhelper.MemberToken`/`MemberEditor`.
 
 | Subject | Password | RoleAssignment | Roles (from assignment) | Scope | Expected result |
 |---------|----------|----------------|-------------------------|-------|-----------------|
@@ -339,9 +343,11 @@ The region catalog (`seca.region`) is served **authn-only**: `--authz-skip-provi
 | Helper | Use |
 |--------|-----|
 | `Token(user, password, scope)` | The token for the **deployed** plugin — a signed JWT under `AUTH_PLUGIN=jwt`, a dummy token otherwise. Backs `AdminEditor` / `IdentityEditor` / `ScopedEditor`, so the suites are plugin-agnostic. |
+| `MemberToken(user, password, tenants)` / `MemberEditor(…)` | Same, but carrying the issuer-asserted `tenants` membership instead of a down-scope. Backs the membership-gate cases in both suites; under either plugin the gate denies (403) a tenant the list omits. |
 | `JWTAuth()` | Whether the stack runs the jwt plugin; plugin-specific tests skip on it. |
 | `JWTKey()` | The fixture ES256 private key. Pass a freshly generated key instead to forge a token the gateway must reject. |
-| `SignJWT(key, subject, scope, exp)` | Sign a token for a subject, with an optional down-scope and an explicit expiry (pass a past time for an expired token). |
+| `SignJWT(key, subject, scope, exp)` | Sign a token for a subject, with an optional down-scope and an explicit expiry (pass a past time for an expired token). Always stamps the deployed `iss`/`aud`; the suite signs its own claim sets when it needs a token without them. |
+| `JWTIssuer` / `JWTAudience` | The `iss`/`aud` the gateways are deployed to require — the same values as `auth.jwt.issuer`/`audience` above. |
 
 The key pair is a committed fixture: the private half is a constant in `authhelper`, the public half is `auth.jwt.key` in `internal/deploy/gateway-values.yaml`. The chart renders it into a Secret, mounts it at `/etc/ecp/jwt/jwt.pub` and passes that path as `--jwt-secret`. It is a Secret rather than a ConfigMap because the same value serves `signingMethod: HS*`, where the file is the shared HMAC secret that mints tokens — see [Verification key](../doc/AUTH.md#verification-key---jwt-secret). To rotate it, regenerate both halves and update both places:
 
@@ -362,7 +368,7 @@ make kind-integration-gateway-global    # dummy tokens (the default)
 make kind-test-all AUTH_PLUGIN=jwt      # the same suites, signed JWTs
 ```
 
-`TestJWTAuthn` (`e2e/jwt_test.go`) is the JWT-specific suite: valid/expired/unsigned-by-us tokens, algorithm-confusion attempts, dummy tokens rejected by the JWT gateway, and the `sub`/`scope` claims driving RBAC. It runs only under `AUTH_PLUGIN=jwt` and is the only test that covers the `--jwt-secret` file → `ParseVerifyKey` → authenticator wiring, since the unit tests build the authenticator from an already-parsed key.
+`TestJWTAuthn` (`e2e/jwt_test.go`) is the JWT-specific suite: valid/expired/unsigned-by-us tokens, algorithm-confusion attempts, wrong/missing `iss`/`aud`, dummy tokens rejected by the JWT gateway, and the `sub`/`tenants`/`scope` claims driving RBAC. It runs only under `AUTH_PLUGIN=jwt` and is the only test that covers the `--jwt-secret` file → `ParseVerifyKey` → authenticator wiring and the `--jwt-issuer`/`--jwt-audience` flags reaching the parser, since the unit tests build the authenticator from an already-parsed key.
 
 To skip auth assertions (e.g. against an auth-disabled gateway):
 

--- a/test/e2e/jwt_test.go
+++ b/test/e2e/jwt_test.go
@@ -44,7 +44,7 @@ func TestJWTAuthn(t *testing.T) {
 	hour := time.Now().Add(time.Hour)
 
 	t.Run("valid JWT is accepted", func(t *testing.T) {
-		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, nil, hour)
+		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, nil, nil, hour)
 		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusOK)
 	})
 
@@ -52,7 +52,7 @@ func TestJWTAuthn(t *testing.T) {
 		// admin holds ra-admin, so the subject carried by the JWT resolves to the
 		// same roles a dummy token's username would: proof the plugins are
 		// interchangeable from the authorization layer's point of view.
-		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, nil, hour)
+		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, nil, nil, hour)
 		requireStatus(t, http.MethodGet, listRolesURL, token, http.StatusOK)
 	})
 
@@ -65,12 +65,12 @@ func TestJWTAuthn(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to generate key: %v", err)
 		}
-		token := authhelper.SignJWT(forged, authhelper.DefaultAuthUser, nil, hour)
+		token := authhelper.SignJWT(forged, authhelper.DefaultAuthUser, nil, nil, hour)
 		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
 	})
 
 	t.Run("expired JWT is rejected", func(t *testing.T) {
-		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, nil, time.Now().Add(-time.Hour))
+		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, nil, nil, time.Now().Add(-time.Hour))
 		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
 	})
 
@@ -106,7 +106,7 @@ func TestJWTAuthn(t *testing.T) {
 		// The same credentials the regional gateway accepts must not open the
 		// global one: proof it really switched plugins rather than accepting
 		// anything that looks like a bearer token.
-		token := authhelper.MakeBearerToken(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, nil)
+		token := authhelper.MakeBearerToken(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, nil, nil)
 		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
 	})
 
@@ -114,7 +114,7 @@ func TestJWTAuthn(t *testing.T) {
 		// "nobody" authenticates but holds no RoleAssignment: authn-only providers
 		// answer, RBAC-governed ones deny. A 403 (not 401) proves the JWT's subject
 		// reached the authorization layer.
-		token := authhelper.SignJWT(authhelper.JWTKey(), "nobody", nil, hour)
+		token := authhelper.SignJWT(authhelper.JWTKey(), "nobody", nil, nil, hour)
 		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusOK)
 		requireStatus(t, http.MethodGet, listRolesURL, token, http.StatusForbidden)
 	})
@@ -122,28 +122,16 @@ func TestJWTAuthn(t *testing.T) {
 	t.Run("JWT from another issuer is rejected", func(t *testing.T) {
 		// Signed with the key the gateway trusts, but minted by someone else: the
 		// --jwt-issuer check is the only thing standing between the two, so a 401
-		// here proves the flag reached the authenticator.
-		token := signClaims(t, jwt.MapClaims{
+		// here proves the flag reached the deployed authenticator. The claim matrix
+		// itself (wrong/missing iss and aud) is covered in gateway/internal/authn.
+		claims := jwt.MapClaims{
 			"sub": authhelper.DefaultAuthUser, "exp": hour.Unix(),
 			"iss": "https://evil.example", "aud": authhelper.JWTAudience,
-		})
-		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
-	})
-
-	t.Run("JWT for another audience is rejected", func(t *testing.T) {
-		// The same key can legitimately sign tokens for other services; --jwt-audience
-		// is what stops one of them being replayed against this API.
-		token := signClaims(t, jwt.MapClaims{
-			"sub": authhelper.DefaultAuthUser, "exp": hour.Unix(),
-			"iss": authhelper.JWTIssuer, "aud": "some-other-api",
-		})
-		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
-	})
-
-	t.Run("JWT without iss/aud is rejected", func(t *testing.T) {
-		// Configuring either claim also makes it mandatory, so a token that simply
-		// omits them is no better than one carrying the wrong values.
-		token := signClaims(t, jwt.MapClaims{"sub": authhelper.DefaultAuthUser, "exp": hour.Unix()})
+		}
+		token, err := jwt.NewWithClaims(authhelper.JWTSigningMethod, claims).SignedString(authhelper.JWTKey())
+		if err != nil {
+			t.Fatalf("failed to sign token: %v", err)
+		}
 		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
 	})
 
@@ -164,24 +152,13 @@ func TestJWTAuthn(t *testing.T) {
 		// admin is unrestricted by RBAC, so any denial here comes from the token's
 		// own scope cap travelling from the JWT into the authorization claim.
 		capped := &resource.TokenScope{Tenants: []string{"other-tenant"}}
-		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, capped, hour)
+		token := authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, capped, nil, hour)
 		requireStatus(t, http.MethodGet, listRolesURL, token, http.StatusForbidden)
 
 		inScope := &resource.TokenScope{Tenants: []string{testTenant}}
-		token = authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, inScope, hour)
+		token = authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, inScope, nil, hour)
 		requireStatus(t, http.MethodGet, listRolesURL, token, http.StatusOK)
 	})
-}
-
-// signClaims signs an arbitrary claim set with the fixture key, for the cases that
-// need a token authhelper deliberately never mints (wrong or missing iss/aud).
-func signClaims(t *testing.T, claims jwt.MapClaims) string {
-	t.Helper()
-	token, err := jwt.NewWithClaims(authhelper.JWTSigningMethod, claims).SignedString(authhelper.JWTKey())
-	if err != nil {
-		t.Fatalf("failed to sign token: %v", err)
-	}
-	return token
 }
 
 // requireStatus issues the request with the given bearer token (omitted when

--- a/test/e2e/jwt_test.go
+++ b/test/e2e/jwt_test.go
@@ -119,6 +119,47 @@ func TestJWTAuthn(t *testing.T) {
 		requireStatus(t, http.MethodGet, listRolesURL, token, http.StatusForbidden)
 	})
 
+	t.Run("JWT from another issuer is rejected", func(t *testing.T) {
+		// Signed with the key the gateway trusts, but minted by someone else: the
+		// --jwt-issuer check is the only thing standing between the two, so a 401
+		// here proves the flag reached the authenticator.
+		token := signClaims(t, jwt.MapClaims{
+			"sub": authhelper.DefaultAuthUser, "exp": hour.Unix(),
+			"iss": "https://evil.example", "aud": authhelper.JWTAudience,
+		})
+		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
+	})
+
+	t.Run("JWT for another audience is rejected", func(t *testing.T) {
+		// The same key can legitimately sign tokens for other services; --jwt-audience
+		// is what stops one of them being replayed against this API.
+		token := signClaims(t, jwt.MapClaims{
+			"sub": authhelper.DefaultAuthUser, "exp": hour.Unix(),
+			"iss": authhelper.JWTIssuer, "aud": "some-other-api",
+		})
+		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
+	})
+
+	t.Run("JWT without iss/aud is rejected", func(t *testing.T) {
+		// Configuring either claim also makes it mandatory, so a token that simply
+		// omits them is no better than one carrying the wrong values.
+		token := signClaims(t, jwt.MapClaims{"sub": authhelper.DefaultAuthUser, "exp": hour.Unix()})
+		requireStatus(t, http.MethodGet, listRegionsURL, token, http.StatusUnauthorized)
+	})
+
+	t.Run("tenants claim gates the request tenant", func(t *testing.T) {
+		// admin is unrestricted by RBAC, so the denial can only come from the
+		// issuer-asserted membership travelling from the JWT into the authorization
+		// claim — the same path the down-scope takes, but one the caller cannot omit.
+		outsider := authhelper.MemberToken(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, []string{"other-tenant"})
+		requireStatus(t, http.MethodGet, listRolesURL, outsider, http.StatusForbidden)
+
+		member := authhelper.MemberToken(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, []string{testTenant})
+		requireStatus(t, http.MethodGet, listRolesURL, member, http.StatusOK)
+		// The gate is authorization, not authentication: an authn-only provider still answers.
+		requireStatus(t, http.MethodGet, listRegionsURL, outsider, http.StatusOK)
+	})
+
 	t.Run("JWT scope claim down-scopes the caller", func(t *testing.T) {
 		// admin is unrestricted by RBAC, so any denial here comes from the token's
 		// own scope cap travelling from the JWT into the authorization claim.
@@ -130,6 +171,17 @@ func TestJWTAuthn(t *testing.T) {
 		token = authhelper.SignJWT(authhelper.JWTKey(), authhelper.DefaultAuthUser, inScope, hour)
 		requireStatus(t, http.MethodGet, listRolesURL, token, http.StatusOK)
 	})
+}
+
+// signClaims signs an arbitrary claim set with the fixture key, for the cases that
+// need a token authhelper deliberately never mints (wrong or missing iss/aud).
+func signClaims(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	token, err := jwt.NewWithClaims(authhelper.JWTSigningMethod, claims).SignedString(authhelper.JWTKey())
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return token
 }
 
 // requireStatus issues the request with the given bearer token (omitted when

--- a/test/integration/gateway-global/authn_test.go
+++ b/test/integration/gateway-global/authn_test.go
@@ -49,7 +49,7 @@ func TestAuthn(t *testing.T) {
 	// and forged/expired signatures are covered by the e2e TestJWTAuthn suite.
 	if !authhelper.JWTAuth() {
 		t.Run("wrong password returns 401", func(t *testing.T) {
-			token := authhelper.MakeBearerToken(authhelper.DefaultAuthUser, "wrong-password", nil)
+			token := authhelper.MakeBearerToken(authhelper.DefaultAuthUser, "wrong-password", nil, nil)
 			req, _ := http.NewRequest(http.MethodGet, listRegionsURL, nil)
 			req.Header.Set("Authorization", "Bearer "+token)
 			resp, err := http.DefaultClient.Do(req)

--- a/test/integration/gateway-global/authz_test.go
+++ b/test/integration/gateway-global/authz_test.go
@@ -133,4 +133,36 @@ func TestAuthz(t *testing.T) {
 			t.Errorf("admin down-scoped to test-tenant: want 200, got %d", resp2.StatusCode())
 		}
 	})
+
+	t.Run("admin outside the token's tenant membership is denied (membership gate)", func(t *testing.T) {
+		// The "tenants" claim is the membership a real issuer stamps on every token it
+		// mints. Unlike the down-scope above it is not something the caller opts into,
+		// so it also caps assignments granted to subs: ["*"]. admin holds ra-admin
+		// (all-access), so a 403 here can only come from the gate.
+		denied := authhelper.MemberEditor(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, []string{"other-tenant"})
+		client, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(denied))
+		if err != nil {
+			t.Fatalf("create client: %v", err)
+		}
+		resp, err := client.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
+		if err != nil {
+			t.Fatalf("list roles (outside membership): %v", err)
+		}
+		if resp.StatusCode() != http.StatusForbidden {
+			t.Errorf("admin outside tenant membership: want 403 in test-tenant, got %d", resp.StatusCode())
+		}
+
+		allowed := authhelper.MemberEditor(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, []string{testTenant, "other-tenant"})
+		client2, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(allowed))
+		if err != nil {
+			t.Fatalf("create client: %v", err)
+		}
+		resp2, err := client2.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
+		if err != nil {
+			t.Fatalf("list roles (member): %v", err)
+		}
+		if resp2.StatusCode() != http.StatusOK {
+			t.Errorf("admin member of test-tenant: want 200, got %d", resp2.StatusCode())
+		}
+	})
 }

--- a/test/integration/gateway-global/authz_test.go
+++ b/test/integration/gateway-global/authz_test.go
@@ -73,34 +73,16 @@ func TestAuthz(t *testing.T) {
 	t.Run("nobody gets 403 (valid creds, no RoleAssignment grants seca.authorization)", func(t *testing.T) {
 		// "nobody" exists in gateway-values.yaml but has no RoleAssignment, so every
 		// RBAC-governed provider denies them: no grant for seca.authorization → 403.
-		editor := authhelper.IdentityEditor("nobody", "nobody-pass")
-		client, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(editor))
-		if err != nil {
-			t.Fatalf("create client: %v", err)
-		}
-		resp, err := client.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
-		if err != nil {
-			t.Fatalf("list roles: %v", err)
-		}
-		if resp.StatusCode() != http.StatusForbidden {
-			t.Errorf("nobody list roles: want 403, got %d", resp.StatusCode())
+		if got := listRolesStatus(t, baseURL, authhelper.IdentityEditor("nobody", "nobody-pass")); got != http.StatusForbidden {
+			t.Errorf("nobody list roles: want 403, got %d", got)
 		}
 	})
 
 	t.Run("erin is denied admin ops in test-tenant (ra-wrong-tenant scoped to other-tenant)", func(t *testing.T) {
 		// erin has ra-wrong-tenant granting e2e-admin, but scoped to Tenants=["other-tenant"],
 		// so test-tenant is out of scope and no other assignment covers her → 403.
-		editor := authhelper.IdentityEditor("erin", "erin-pass")
-		client, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(editor))
-		if err != nil {
-			t.Fatalf("create client: %v", err)
-		}
-		resp, err := client.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
-		if err != nil {
-			t.Fatalf("list roles: %v", err)
-		}
-		if resp.StatusCode() != http.StatusForbidden {
-			t.Errorf("erin list roles in test-tenant: want 403, got %d", resp.StatusCode())
+		if got := listRolesStatus(t, baseURL, authhelper.IdentityEditor("erin", "erin-pass")); got != http.StatusForbidden {
+			t.Errorf("erin list roles in test-tenant: want 403, got %d", got)
 		}
 	})
 
@@ -108,29 +90,13 @@ func TestAuthz(t *testing.T) {
 		// admin (ra-admin) has all-access, but a token down-scoped to other-tenant must not
 		// authorize operations in test-tenant; a token scoped to test-tenant still works.
 		denied := authhelper.ScopedEditor(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, &resource.TokenScope{Tenants: []string{"other-tenant"}})
-		client, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(denied))
-		if err != nil {
-			t.Fatalf("create client: %v", err)
-		}
-		resp, err := client.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
-		if err != nil {
-			t.Fatalf("list roles (down-scoped): %v", err)
-		}
-		if resp.StatusCode() != http.StatusForbidden {
-			t.Errorf("admin down-scoped to other-tenant: want 403 in test-tenant, got %d", resp.StatusCode())
+		if got := listRolesStatus(t, baseURL, denied); got != http.StatusForbidden {
+			t.Errorf("admin down-scoped to other-tenant: want 403 in test-tenant, got %d", got)
 		}
 
 		allowed := authhelper.ScopedEditor(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, &resource.TokenScope{Tenants: []string{testTenant}})
-		client2, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(allowed))
-		if err != nil {
-			t.Fatalf("create client: %v", err)
-		}
-		resp2, err := client2.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
-		if err != nil {
-			t.Fatalf("list roles (in-scope): %v", err)
-		}
-		if resp2.StatusCode() != http.StatusOK {
-			t.Errorf("admin down-scoped to test-tenant: want 200, got %d", resp2.StatusCode())
+		if got := listRolesStatus(t, baseURL, allowed); got != http.StatusOK {
+			t.Errorf("admin down-scoped to test-tenant: want 200, got %d", got)
 		}
 	})
 
@@ -140,29 +106,29 @@ func TestAuthz(t *testing.T) {
 		// so it also caps assignments granted to subs: ["*"]. admin holds ra-admin
 		// (all-access), so a 403 here can only come from the gate.
 		denied := authhelper.MemberEditor(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, []string{"other-tenant"})
-		client, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(denied))
-		if err != nil {
-			t.Fatalf("create client: %v", err)
-		}
-		resp, err := client.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
-		if err != nil {
-			t.Fatalf("list roles (outside membership): %v", err)
-		}
-		if resp.StatusCode() != http.StatusForbidden {
-			t.Errorf("admin outside tenant membership: want 403 in test-tenant, got %d", resp.StatusCode())
+		if got := listRolesStatus(t, baseURL, denied); got != http.StatusForbidden {
+			t.Errorf("admin outside tenant membership: want 403 in test-tenant, got %d", got)
 		}
 
 		allowed := authhelper.MemberEditor(authhelper.DefaultAuthUser, authhelper.DefaultAuthPassword, []string{testTenant, "other-tenant"})
-		client2, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(allowed))
-		if err != nil {
-			t.Fatalf("create client: %v", err)
-		}
-		resp2, err := client2.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
-		if err != nil {
-			t.Fatalf("list roles (member): %v", err)
-		}
-		if resp2.StatusCode() != http.StatusOK {
-			t.Errorf("admin member of test-tenant: want 200, got %d", resp2.StatusCode())
+		if got := listRolesStatus(t, baseURL, allowed); got != http.StatusOK {
+			t.Errorf("admin member of test-tenant: want 200, got %d", got)
 		}
 	})
+}
+
+// listRolesStatus lists the roles of testTenant as whatever identity the editor
+// authenticates and returns the HTTP status. Every case above differs only in that
+// identity, so the client dance lives here once.
+func listRolesStatus(t *testing.T, baseURL string, editor authv1.RequestEditorFn) int {
+	t.Helper()
+	client, err := authv1.NewClientWithResponses(baseURL+"/providers/seca.authorization", authv1.WithRequestEditorFn(editor))
+	if err != nil {
+		t.Fatalf("create client: %v", err)
+	}
+	resp, err := client.ListRolesWithResponse(context.Background(), testTenant, &authv1.ListRolesParams{})
+	if err != nil {
+		t.Fatalf("list roles: %v", err)
+	}
+	return resp.StatusCode()
 }

--- a/test/internal/authhelper/authhelpers.go
+++ b/test/internal/authhelper/authhelpers.go
@@ -54,12 +54,34 @@ func Token(username, password string, scope *resource.TokenScope) string {
 // [resource.TokenScope] and its json tags. Roles are never carried by the token — they are
 // resolved from RoleAssignments in the caller's tenant namespace.
 func MakeBearerToken(username, password string, scope *resource.TokenScope) string {
+	return dummyToken(username, password, scope, nil)
+}
+
+// MemberToken mints a token for the deployed authenticator carrying the issuer-asserted
+// tenant membership (the "tenants" claim) instead of a caller-requested down-scope. The
+// gateway gates every request on it: a tenant outside the list is denied even when RBAC
+// grants the subject, and unlike the token scope it also caps a subs: ["*"] assignment.
+func MemberToken(username, password string, tenants []string) string {
+	if JWTAuth() {
+		return signJWT(JWTKey(), username, nil, tenants, time.Now().Add(time.Hour))
+	}
+	return dummyToken(username, password, nil, tenants)
+}
+
+// MemberEditor returns a request editor for a token carrying the given tenant membership.
+func MemberEditor(username, password string, tenants []string) func(ctx context.Context, req *http.Request) error {
+	return bearerEditor(MemberToken(username, password, tenants))
+}
+
+// dummyToken encodes the Dummy authenticator's base64 JSON payload.
+func dummyToken(username, password string, scope *resource.TokenScope, tenants []string) string {
 	type payload struct {
 		Username string               `json:"username"`
 		Password string               `json:"password"`
 		Scope    *resource.TokenScope `json:"scope,omitempty"`
+		Tenants  []string             `json:"tenants,omitempty"`
 	}
-	b, err := json.Marshal(payload{Username: username, Password: password, Scope: scope})
+	b, err := json.Marshal(payload{Username: username, Password: password, Scope: scope, Tenants: tenants})
 	if err != nil {
 		panic("MakeBearerToken: marshal failed: " + err.Error())
 	}
@@ -126,14 +148,36 @@ func JWTKey() *ecdsa.PrivateKey {
 	return key
 }
 
+// JWTIssuer and JWTAudience are the iss/aud the gateways are deployed to require
+// (auth.jwt.issuer / auth.jwt.audience in internal/deploy/gateway-values.yaml). Every
+// token the suites mint carries them; a token with either wrong or missing is a 401.
+const (
+	JWTIssuer   = "https://issuer.e2e.ecp.local"
+	JWTAudience = "ecp-e2e"
+)
+
 // SignJWT builds a standard signed JWT for the given subject. The subject becomes
 // Identity.Subject and is matched against RoleAssignment.Spec.Subs, exactly as the
 // dummy token's username is; the optional scope down-scopes the caller. Pass a key
 // other than JWTKey() to forge a token the gateway must reject.
 func SignJWT(key *ecdsa.PrivateKey, subject string, scope *resource.TokenScope, exp time.Time) string {
-	claims := jwt.MapClaims{"sub": subject, "exp": exp.Unix()}
+	return signJWT(key, subject, scope, nil, exp)
+}
+
+// signJWT signs the token both SignJWT and MemberToken hand out: registered claims plus
+// the deployed iss/aud, the optional down-scope and the optional tenant membership.
+func signJWT(key *ecdsa.PrivateKey, subject string, scope *resource.TokenScope, tenants []string, exp time.Time) string {
+	claims := jwt.MapClaims{
+		"sub": subject,
+		"exp": exp.Unix(),
+		"iss": JWTIssuer,
+		"aud": JWTAudience,
+	}
 	if scope != nil {
 		claims["scope"] = scope
+	}
+	if len(tenants) > 0 {
+		claims["tenants"] = tenants
 	}
 	signed, err := jwt.NewWithClaims(JWTSigningMethod, claims).SignedString(key)
 	if err != nil {

--- a/test/internal/authhelper/authhelpers.go
+++ b/test/internal/authhelper/authhelpers.go
@@ -44,17 +44,9 @@ func JWTAuth() bool {
 // Identity.Subject, so RBAC resolves identically either way.
 func Token(username, password string, scope *resource.TokenScope) string {
 	if JWTAuth() {
-		return SignJWT(JWTKey(), username, scope, time.Now().Add(time.Hour))
+		return SignJWT(JWTKey(), username, scope, nil, time.Now().Add(time.Hour))
 	}
-	return MakeBearerToken(username, password, scope)
-}
-
-// MakeBearerToken encodes a Dummy authenticator bearer token.
-// The token is base64(JSON{"username":…,"password":…,"scope":…}); the optional scope reuses
-// [resource.TokenScope] and its json tags. Roles are never carried by the token — they are
-// resolved from RoleAssignments in the caller's tenant namespace.
-func MakeBearerToken(username, password string, scope *resource.TokenScope) string {
-	return dummyToken(username, password, scope, nil)
+	return MakeBearerToken(username, password, scope, nil)
 }
 
 // MemberToken mints a token for the deployed authenticator carrying the issuer-asserted
@@ -63,9 +55,9 @@ func MakeBearerToken(username, password string, scope *resource.TokenScope) stri
 // grants the subject, and unlike the token scope it also caps a subs: ["*"] assignment.
 func MemberToken(username, password string, tenants []string) string {
 	if JWTAuth() {
-		return signJWT(JWTKey(), username, nil, tenants, time.Now().Add(time.Hour))
+		return SignJWT(JWTKey(), username, nil, tenants, time.Now().Add(time.Hour))
 	}
-	return dummyToken(username, password, nil, tenants)
+	return MakeBearerToken(username, password, nil, tenants)
 }
 
 // MemberEditor returns a request editor for a token carrying the given tenant membership.
@@ -73,8 +65,12 @@ func MemberEditor(username, password string, tenants []string) func(ctx context.
 	return bearerEditor(MemberToken(username, password, tenants))
 }
 
-// dummyToken encodes the Dummy authenticator's base64 JSON payload.
-func dummyToken(username, password string, scope *resource.TokenScope, tenants []string) string {
+// MakeBearerToken encodes a Dummy authenticator bearer token: base64(JSON{"username":…,
+// "password":…,"scope":…,"tenants":…}); the optional scope reuses [resource.TokenScope]
+// and its json tags, and the optional tenants list stands in for the membership a real
+// issuer stamps. Roles are never carried by the token — they are resolved from
+// RoleAssignments in the caller's tenant namespace.
+func MakeBearerToken(username, password string, scope *resource.TokenScope, tenants []string) string {
 	type payload struct {
 		Username string               `json:"username"`
 		Password string               `json:"password"`
@@ -156,17 +152,12 @@ const (
 	JWTAudience = "ecp-e2e"
 )
 
-// SignJWT builds a standard signed JWT for the given subject. The subject becomes
-// Identity.Subject and is matched against RoleAssignment.Spec.Subs, exactly as the
-// dummy token's username is; the optional scope down-scopes the caller. Pass a key
-// other than JWTKey() to forge a token the gateway must reject.
-func SignJWT(key *ecdsa.PrivateKey, subject string, scope *resource.TokenScope, exp time.Time) string {
-	return signJWT(key, subject, scope, nil, exp)
-}
-
-// signJWT signs the token both SignJWT and MemberToken hand out: registered claims plus
-// the deployed iss/aud, the optional down-scope and the optional tenant membership.
-func signJWT(key *ecdsa.PrivateKey, subject string, scope *resource.TokenScope, tenants []string, exp time.Time) string {
+// SignJWT builds a standard signed JWT for the given subject: registered claims plus the
+// deployed iss/aud, the optional down-scope and the optional tenant membership. The
+// subject becomes Identity.Subject and is matched against RoleAssignment.Spec.Subs,
+// exactly as the dummy token's username is. Pass a key other than JWTKey() to forge a
+// token the gateway must reject.
+func SignJWT(key *ecdsa.PrivateKey, subject string, scope *resource.TokenScope, tenants []string, exp time.Time) string {
 	claims := jwt.MapClaims{
 		"sub": subject,
 		"exp": exp.Unix(),

--- a/test/internal/deploy/gateway-values.yaml
+++ b/test/internal/deploy/gateway-values.yaml
@@ -43,6 +43,12 @@ auth:
     # WARNING: the private half is published in this repository, so anyone can
     # mint a token these gateways accept. Never use this key pair in production.
     signingMethod: ES256
+    # Expected iss/aud, mirrored by internal/authhelper (JWTIssuer/JWTAudience) so
+    # every token the suites mint carries them. They make the e2e run cover the
+    # --jwt-issuer/--jwt-audience path: a token signed with the fixture key but
+    # minted for anything else comes back 401.
+    issuer: https://issuer.e2e.ecp.local
+    audience: ecp-e2e
     key: |
       -----BEGIN PUBLIC KEY-----
       MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEACNi0y/+o+9tCWzA7H6N+dJZm74M


### PR DESCRIPTION
Finishes the remaining checklist in `doc/AUTH-SPEC-REVIEW.md` §6.

- `--jwt-issuer` / `--jwt-audience`: `iss`/`aud` are verified when configured, and configuring one makes that claim mandatory in the token. Chart values `auth.jwt.issuer` / `auth.jwt.audience`.
- Issuer-asserted tenant membership: the token's `tenants` claim reaches `Identity.MemberTenants` and gates the request's tenant (403). Unlike the caller-asserted `scope`, it cannot be omitted, so it also caps a `subs: ["*"]` assignment.
- Subject claim (`sub`) and revocation strategy (short TTLs + mandatory `exp`) recorded in `doc/AUTH.md`; JWKS and a configurable claim name are documented as deliberately out of scope.

Tests: unit (authenticators — including the full wrong/missing `iss`/`aud` matrix — evaluator, middleware), integration (membership gate under the dummy plugin) and e2e (flag wiring via a token from another issuer, membership gate, jwt plugin). `make -C test kind-test-all` green with both `AUTH_PLUGIN=dummy` and `AUTH_PLUGIN=jwt`; `make pre-merge-ctzd` green (47/47 stages).

closes #323